### PR TITLE
BACKLOG-22449: Avoid css url() to be duplicated in css folder during scss processing

### DIFF
--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -23,7 +23,7 @@
 
 .lux-404page {
     height: 95vh;
-    background: url(../../assets/img/bg-404.jpg) no-repeat;
+    background: url(../assets/img/bg-404.jpg) no-repeat;
     background-size: cover;
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,12 @@ module.exports = env => {
                         test: /\.scss$/,
                         use: [
                             MiniCssExtractPlugin.loader,
-                            'css-loader',
+                            {
+                                loader: 'css-loader',
+                                options: {
+                                    url: false
+                                }
+                            },
                             'sass-loader'
                         ]
                     }
@@ -93,19 +98,6 @@ module.exports = env => {
                                 ]
                             }
                         }
-                    },
-                    {
-                        test: /\.s[ac]ss$/i,
-                        use: [
-                            'style-loader',
-                            {
-                                loader: 'css-loader',
-                                options: {
-                                    modules: true
-                                }
-                            },
-                            'sass-loader'
-                        ]
                     }
                 ]
             },


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-22449

## Description

Avoid webpack to interpret url() during scss processing to evict assets images duplication in the target  css folder.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
