### PR TITLE
BACKLOG-22737 : use yarn 4 without pnp

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: corepack enable
       - uses: jahia/jahia-modules-action/update-signature@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
@@ -26,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: corepack enable
       - uses: jahia/jahia-modules-action/build-npm@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
@@ -48,6 +50,7 @@ jobs:
         with:
           node-version: 'lts/*'
       - uses: actions/checkout@v4
+      - run: corepack enable
       - uses: jahia/jahia-modules-action/integration-tests@v2
         with:
           testrail_project: Demo Site NPM

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,2 @@
-yarnPath: .yarn/releases/yarn-4.1.1.cjs
+# Remove this to use Yarn Plug'n'Play instead of node_modules (https://yarnpkg.com/features/pnp)
+nodeLinker: node-modules

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "deploy": "jahia-deploy",
     "watch": "webpack --mode=development --env deploy --watch",
     "lint": "eslint .",
-    "test": "yarn lint",
-    "postinstall": "yarn dlx @yarnpkg/sdks vscode"
+    "test": "yarn lint"
   },
   "jahia": {
     "required-version": "8.2.0.0-SNAPSHOT",
@@ -75,7 +74,7 @@
   },
   "engines": {
     "node": ">=16.0.0",
-    "yarn": ">=3.0.0"
+    "yarn": ">=4.0.0"
   },
   "packageManager": "yarn@4.1.1"
 }


### PR DESCRIPTION
Done :

- Removed yarnPath because this is not the preferred way of specifying the node version anymore (it’s corepack since yarn v4.x : https://yarnpkg.com/blog/release/4.0#installing-yarn)

- Added ‘nodeLinker: node-modules’ to .yarnrc to stop using pnp

- Removed postInstall script because the script is necessary for pnp only (https://yarnpkg.com/getting-started/editor-sdks) and was causing build error

