### PR TITLE
BACKLOG-23366: Migrate to @jahia/javascript-modules-library

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     }
   },
   "dependencies": {
-    "@jahia/javascript-modules-library": "/Users/baptistegrimaud/Documents/code/jahia/BACKLOG-23366-javascript-modules/javascript-modules/javascript-modules-library/target/javascript-modules-library-0.0.1-SNAPSHOT.tgz",
+    "@jahia/javascript-modules-library": "^0.0.4",
     "bootstrap": "^5.3.3",
     "graphql": "^16.7.1",
     "i18next": "^23.10.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     }
   },
   "dependencies": {
-    "@jahia/js-server-core": "^0.0.15",
+    "@jahia/javascript-modules-library": "/Users/baptistegrimaud/Documents/code/jahia/BACKLOG-23366-javascript-modules/javascript-modules/javascript-modules-library/target/javascript-modules-library-0.0.1-SNAPSHOT.tgz",
     "bootstrap": "^5.3.3",
     "graphql": "^16.7.1",
     "i18next": "^23.10.1",

--- a/src/server/components/CMPreview.jsx
+++ b/src/server/components/CMPreview.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {AddResources, useUrlBuilder} from '@jahia/js-server-core';
+import {AddResources, useUrlBuilder} from '@jahia/javascript-modules-library';
 
 export const CMPreview = ({className, children}) => {
     const {buildStaticUrl} = useUrlBuilder();

--- a/src/server/components/HtmlFooter.jsx
+++ b/src/server/components/HtmlFooter.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import {Col, Row, Section} from './grid';
 import {useTranslation} from 'react-i18next';
-import {Render} from '@jahia/js-server-core';
+import {Render} from '@jahia/javascript-modules-library';
 
 const loginForm = {
     name: 'loginForm',

--- a/src/server/components/HtmlHead.jsx
+++ b/src/server/components/HtmlHead.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {AddResources, useServerContext, useUrlBuilder} from '@jahia/js-server-core';
+import {AddResources, useServerContext, useUrlBuilder} from '@jahia/javascript-modules-library';
 import {SeoMetaTags} from './SeoMetaTags';
 
 export const HtmlHead = ({children}) => {

--- a/src/server/components/SeoMetaTags.jsx
+++ b/src/server/components/SeoMetaTags.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {buildUrl, getNodeProps, useServerContext} from '@jahia/js-server-core';
+import {buildUrl, getNodeProps, useServerContext} from '@jahia/javascript-modules-library';
 
 export const SeoMetaTags = () => {
     const {currentNode, currentResource, renderContext} = useServerContext();

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,6 +1,6 @@
 import * as jahiaViews from './views';
 import * as jahiaTemplates from './templates';
-import {registerJahiaComponents} from '@jahia/js-server-core';
+import {registerJahiaComponents} from '@jahia/javascript-modules-library';
 // Import './scss/styles.scss';
 
 // import i18next from 'i18next';

--- a/src/server/layouts/MainLayout.jsx
+++ b/src/server/layouts/MainLayout.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {HtmlFooter, HtmlHead} from '../components';
-import {AbsoluteArea, AddResources} from '@jahia/js-server-core';
+import {AbsoluteArea, AddResources} from '@jahia/javascript-modules-library';
 
 // Const navMenu = {
 //     name: 'navMenu',

--- a/src/server/templates/agency/AgencyDefault.jsx
+++ b/src/server/templates/agency/AgencyDefault.jsx
@@ -3,7 +3,7 @@ import {MainLayout} from '../../layouts';
 import {
     useServerContext,
     Render, defineJahiaComponent
-} from '@jahia/js-server-core';
+} from '@jahia/javascript-modules-library';
 
 export const AgencyDefault = () => {
     const {currentNode} = useServerContext();

--- a/src/server/templates/estate/EstateDefault.jsx
+++ b/src/server/templates/estate/EstateDefault.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Render, useServerContext, defineJahiaComponent} from '@jahia/js-server-core';
+import {Render, useServerContext, defineJahiaComponent} from '@jahia/javascript-modules-library';
 import {MainLayout} from '../../layouts';
 
 export const EstateDefault = () => {

--- a/src/server/templates/page/PageCentered.jsx
+++ b/src/server/templates/page/PageCentered.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Area, defineJahiaComponent} from '@jahia/js-server-core';
+import {Area, defineJahiaComponent} from '@jahia/javascript-modules-library';
 import {MainLayout} from '../../layouts';
 
 export const PageCentered = () => {

--- a/src/server/templates/page/PageDestination.jsx
+++ b/src/server/templates/page/PageDestination.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Area, getNodeProps, Render, useServerContext, defineJahiaComponent} from '@jahia/js-server-core';
+import {Area, getNodeProps, Render, useServerContext, defineJahiaComponent} from '@jahia/javascript-modules-library';
 import {MainLayout} from '../../layouts';
 import {Row, Section} from '../../components';
 

--- a/src/server/templates/page/PageDestinations.jsx
+++ b/src/server/templates/page/PageDestinations.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Area, defineJahiaComponent} from '@jahia/js-server-core';
+import {Area, defineJahiaComponent} from '@jahia/javascript-modules-library';
 import {MainLayout} from '../../layouts';
 import {Row, Section} from '../../components';
 

--- a/src/server/templates/page/PageHome.jsx
+++ b/src/server/templates/page/PageHome.jsx
@@ -1,15 +1,11 @@
 import React from 'react';
-import {Area, defineJahiaComponent} from '@jahia/js-server-core';
+import {Area, defineJahiaComponent} from '@jahia/javascript-modules-library';
 import {MainLayout} from '../../layouts';
 
 export const PageHome = () => {
     return (
         <MainLayout
-            head={
-                <>
-                    <title>LuXE Demo</title>
-                </>
-            }
+            head={<title>LuXE Demo</title>}
         >
             <Area name="heading" allowedTypes={['luxe:header']} numberOfItems={1}/>
             <Area name="main" allowedTypes={['luxe:section']}/>

--- a/src/server/templates/realtor/RealtorDefault.jsx
+++ b/src/server/templates/realtor/RealtorDefault.jsx
@@ -4,7 +4,7 @@ import {
     useServerContext,
     Render,
     defineJahiaComponent
-} from '@jahia/js-server-core';
+} from '@jahia/javascript-modules-library';
 
 export const RealtorDefault = () => {
     const {currentNode} = useServerContext();

--- a/src/server/views/agency/AgencyCm.jsx
+++ b/src/server/views/agency/AgencyCm.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
     Render, useServerContext, defineJahiaComponent
-} from '@jahia/js-server-core';
+} from '@jahia/javascript-modules-library';
 import {CMPreview} from '../../components';
 
 export const AgencyCm = () => {

--- a/src/server/views/agency/AgencyDefault.jsx
+++ b/src/server/views/agency/AgencyDefault.jsx
@@ -4,7 +4,7 @@ import {
     getNodeProps,
     useUrlBuilder,
     server, defineJahiaComponent
-} from '@jahia/js-server-core';
+} from '@jahia/javascript-modules-library';
 import {useTranslation} from 'react-i18next';
 
 export const AgencyDefault = () => {

--- a/src/server/views/agency/AgencyFullPage.jsx
+++ b/src/server/views/agency/AgencyFullPage.jsx
@@ -7,7 +7,7 @@ import {
     server,
     useServerContext,
     useUrlBuilder
-} from '@jahia/js-server-core';
+} from '@jahia/javascript-modules-library';
 
 import {useTranslation} from 'react-i18next';
 import {Col, ContentHeader, HeadingSection, Row, Section, Table} from '../../components';

--- a/src/server/views/cols/ColsDefault.jsx
+++ b/src/server/views/cols/ColsDefault.jsx
@@ -4,7 +4,7 @@ import {
     getNodeProps,
     Area,
     defineJahiaComponent
-} from '@jahia/js-server-core';
+} from '@jahia/javascript-modules-library';
 import clsx from 'clsx';
 
 export const ColsDefault = () => {

--- a/src/server/views/estate/EstateCm.jsx
+++ b/src/server/views/estate/EstateCm.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {useServerContext, Render, defineJahiaComponent} from '@jahia/js-server-core';
+import {useServerContext, Render, defineJahiaComponent} from '@jahia/javascript-modules-library';
 import {CMPreview} from '../../components';
 
 export const EstateCm = () => {

--- a/src/server/views/estate/EstateDefault.jsx
+++ b/src/server/views/estate/EstateDefault.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {defineJahiaComponent, getNodeProps, server, useServerContext, useUrlBuilder} from '@jahia/js-server-core';
+import {defineJahiaComponent, getNodeProps, server, useServerContext, useUrlBuilder} from '@jahia/javascript-modules-library';
 import {useTranslation} from 'react-i18next';
 
 export const EstateDefault = () => {

--- a/src/server/views/estate/EstateFullPage.jsx
+++ b/src/server/views/estate/EstateFullPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {defineJahiaComponent, getNodeProps, server, useServerContext, useUrlBuilder} from '@jahia/js-server-core';
+import {defineJahiaComponent, getNodeProps, server, useServerContext, useUrlBuilder} from '@jahia/javascript-modules-library';
 import {Col, Figure, PageTitle, Row, Section} from '../../components';
 import {useTranslation} from 'react-i18next';
 

--- a/src/server/views/header/HeaderDefault.jsx
+++ b/src/server/views/header/HeaderDefault.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {useServerContext, getNodeProps, server, defineJahiaComponent} from '@jahia/js-server-core';
+import {useServerContext, getNodeProps, server, defineJahiaComponent} from '@jahia/javascript-modules-library';
 
 export const HeaderDefault = () => {
     const {currentNode, renderContext} = useServerContext();

--- a/src/server/views/header/HeaderTextDown.jsx
+++ b/src/server/views/header/HeaderTextDown.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {useServerContext, getNodeProps, server, defineJahiaComponent} from '@jahia/js-server-core';
+import {useServerContext, getNodeProps, server, defineJahiaComponent} from '@jahia/javascript-modules-library';
 import {Figure, Row} from '../../components';
 
 export const HeaderTextDown = () => {

--- a/src/server/views/header/HeaderTextUp.jsx
+++ b/src/server/views/header/HeaderTextUp.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {useServerContext, getNodeProps, server, defineJahiaComponent} from '@jahia/js-server-core';
+import {useServerContext, getNodeProps, server, defineJahiaComponent} from '@jahia/javascript-modules-library';
 import {Figure, PageTitle, Row} from '../../components';
 
 export const HeaderTextUp = () => {

--- a/src/server/views/highlightNumber/HighlightNumberDefault.jsx
+++ b/src/server/views/highlightNumber/HighlightNumberDefault.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {useServerContext, getNodeProps, defineJahiaComponent} from '@jahia/js-server-core';
+import {useServerContext, getNodeProps, defineJahiaComponent} from '@jahia/javascript-modules-library';
 import clsx from 'clsx';
 
 export const HighlightNumberDefault = ({className}) => {

--- a/src/server/views/jcrQuery/JcrQueryDefault.jsx
+++ b/src/server/views/jcrQuery/JcrQueryDefault.jsx
@@ -6,7 +6,7 @@ import {
     Render,
     getNodesByJCRQuery,
     defineJahiaComponent
-} from '@jahia/js-server-core';
+} from '@jahia/javascript-modules-library';
 import {Col, HeadingSection, Row} from '../../components';
 import {useTranslation} from 'react-i18next';
 import {buildQuery} from './utils';

--- a/src/server/views/jcrQuery/JcrQueryDestinationGrid.jsx
+++ b/src/server/views/jcrQuery/JcrQueryDestinationGrid.jsx
@@ -6,7 +6,7 @@ import {
     Render,
     getNodesByJCRQuery,
     defineJahiaComponent
-} from '@jahia/js-server-core';
+} from '@jahia/javascript-modules-library';
 import {Col, HeadingSection, Row} from '../../components';
 import {useTranslation} from 'react-i18next';
 import {buildQuery} from './utils';

--- a/src/server/views/jcrQuery/JcrQueryInline.jsx
+++ b/src/server/views/jcrQuery/JcrQueryInline.jsx
@@ -6,7 +6,7 @@ import {
     Render,
     getNodesByJCRQuery,
     defineJahiaComponent
-} from '@jahia/js-server-core';
+} from '@jahia/javascript-modules-library';
 import {HeadingSection} from '../../components';
 import {useTranslation} from 'react-i18next';
 import {buildQuery} from './utils';

--- a/src/server/views/loginForm/LoginForm.jsx
+++ b/src/server/views/loginForm/LoginForm.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {HydrateInBrowser, useServerContext, getNodeProps, defineJahiaComponent} from '@jahia/js-server-core';
+import {HydrateInBrowser, useServerContext, getNodeProps, defineJahiaComponent} from '@jahia/javascript-modules-library';
 import LoginComponent from '../../../client/LoginComponent';
 
 export const LoginForm = () => {

--- a/src/server/views/navMenu/LanguageSwitcher.jsx
+++ b/src/server/views/navMenu/LanguageSwitcher.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {buildUrl, useServerContext} from '@jahia/js-server-core';
+import {buildUrl, useServerContext} from '@jahia/javascript-modules-library';
 import clsx from 'clsx';
 
 const getSiteLanguageAsLocales = renderContext => {

--- a/src/server/views/navMenu/NavMenuDefault.jsx
+++ b/src/server/views/navMenu/NavMenuDefault.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {useServerContext, getNodeProps, buildNavMenu, server, defineJahiaComponent} from '@jahia/js-server-core';
+import {useServerContext, getNodeProps, buildNavMenu, server, defineJahiaComponent} from '@jahia/javascript-modules-library';
 import clsx from 'clsx';
 import {LanguageSwitcher} from './LanguageSwitcher';
 

--- a/src/server/views/navMenu/NavMenuIllustrated.jsx
+++ b/src/server/views/navMenu/NavMenuIllustrated.jsx
@@ -6,7 +6,7 @@ import {
     server,
     useServerContext,
     useUrlBuilder
-} from '@jahia/js-server-core';
+} from '@jahia/javascript-modules-library';
 import {Section, TextIllustrated} from '../../components';
 import PropTypes from 'prop-types';
 import {useTranslation} from 'react-i18next';

--- a/src/server/views/page/PageDefault.jsx
+++ b/src/server/views/page/PageDefault.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {defineJahiaComponent, getNodeProps, server, useServerContext, useUrlBuilder} from '@jahia/js-server-core';
+import {defineJahiaComponent, getNodeProps, server, useServerContext, useUrlBuilder} from '@jahia/javascript-modules-library';
 
 export const PageDefault = () => {
     const {currentNode, renderContext} = useServerContext();

--- a/src/server/views/page/PageRelatedContent.jsx
+++ b/src/server/views/page/PageRelatedContent.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {useTranslation} from 'react-i18next';
 import {HeadingSection, Section} from '../../components';
-import {getNodeProps, getNodesByJCRQuery, Render, server, useServerContext, defineJahiaComponent} from '@jahia/js-server-core';
+import {getNodeProps, getNodesByJCRQuery, Render, server, useServerContext, defineJahiaComponent} from '@jahia/javascript-modules-library';
 
 export const PageRelatedContent = () => {
     const {t} = useTranslation();

--- a/src/server/views/realtor/RealtorCm.jsx
+++ b/src/server/views/realtor/RealtorCm.jsx
@@ -3,7 +3,7 @@ import {
     useServerContext,
     Render,
     defineJahiaComponent
-} from '@jahia/js-server-core';
+} from '@jahia/javascript-modules-library';
 import {CMPreview} from '../../components';
 
 export const RealtorCm = () => {

--- a/src/server/views/realtor/RealtorDefault.jsx
+++ b/src/server/views/realtor/RealtorDefault.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {defineJahiaComponent, getNodeProps, server, useServerContext, useUrlBuilder} from '@jahia/js-server-core';
+import {defineJahiaComponent, getNodeProps, server, useServerContext, useUrlBuilder} from '@jahia/javascript-modules-library';
 import {useTranslation} from 'react-i18next';
 
 export const RealtorDefault = () => {

--- a/src/server/views/realtor/RealtorFullPage.jsx
+++ b/src/server/views/realtor/RealtorFullPage.jsx
@@ -7,7 +7,7 @@ import {
     server,
     useServerContext,
     useUrlBuilder
-} from '@jahia/js-server-core';
+} from '@jahia/javascript-modules-library';
 import {useTranslation} from 'react-i18next';
 import {Col, ContentHeader, HeadingSection, Row, Section, Table} from '../../components';
 

--- a/src/server/views/section/SectionDefault.jsx
+++ b/src/server/views/section/SectionDefault.jsx
@@ -4,7 +4,7 @@ import {
     useServerContext,
     getNodeProps,
     Render, AddContentButtons, getChildNodes, defineJahiaComponent
-} from '@jahia/js-server-core';
+} from '@jahia/javascript-modules-library';
 import clsx from 'clsx';
 
 const getArrangement = arrangement => {

--- a/src/server/views/textIllustrated/TextIllustratedDefault.jsx
+++ b/src/server/views/textIllustrated/TextIllustratedDefault.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {defineJahiaComponent, getNodeProps, server, useServerContext, useUrlBuilder} from '@jahia/js-server-core';
+import {defineJahiaComponent, getNodeProps, server, useServerContext, useUrlBuilder} from '@jahia/javascript-modules-library';
 
 import {TextIllustrated} from '../../components';
 

--- a/tests/provisioning-manifest-build.yml
+++ b/tests/provisioning-manifest-build.yml
@@ -1,0 +1,5 @@
+# uninstall the old npm-modules-engine module during the transition to the replacement module: javascript-modules-engine
+- uninstallBundle:
+    - 'mvn:org.jahia.modules/npm-modules-engine'
+- installBundle:
+    - 'mvn:org.jahia.modules/javascript-modules-engine'

--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -1,5 +1,5 @@
 - installBundle:
     - 'npm:mvn:org.jahia.modules.npm/luxe-jahia-demo/0.4.0-SNAPSHOT/tgz'
-    - 'mvn:org.jahia.modules/npm-modules-engine'
+    - 'mvn:org.jahia.modules/javascript-modules-engine'
   autoStart: true
   uninstallPreviousVersion: true

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,7 @@ module.exports = (env, argv) => {
     let optimization = isDevelopment ? {} : {
         minimizer: [
             // This is required to make hydration working, as its implementation relies on the class name of the React component.
-            // See InBrowser.jsx in js-server-core for details
+            // See InBrowser.jsx in javascript-modules-library for details
             new TerserPlugin({
                 terserOptions: {
                     keep_classnames: true,
@@ -165,11 +165,11 @@ module.exports = (env, argv) => {
             },
             externals: {
                 // Those libraries are supplied to webpack at runtime (by the npm-module-engine project), and are not packaged in the output bundle
-                '@jahia/js-server-core': 'jsServerCoreLibraryBuilder.getLibrary()',
-                react: 'jsServerCoreLibraryBuilder.getSharedLibrary(\'react\')',
-                'react-i18next': 'jsServerCoreLibraryBuilder.getSharedLibrary(\'react-i18next\')',
-                i18next: 'jsServerCoreLibraryBuilder.getSharedLibrary(\'i18next\')',
-                'styled-jsx/style': 'jsServerCoreLibraryBuilder.getSharedLibrary(\'styled-jsx\')',
+                '@jahia/javascript-modules-library': 'javascriptModulesLibraryBuilder.getLibrary()',
+                react: 'javascriptModulesLibraryBuilder.getSharedLibrary(\'react\')',
+                'react-i18next': 'javascriptModulesLibraryBuilder.getSharedLibrary(\'react-i18next\')',
+                i18next: 'javascriptModulesLibraryBuilder.getSharedLibrary(\'i18next\')',
+                'styled-jsx/style': 'javascriptModulesLibraryBuilder.getSharedLibrary(\'styled-jsx\')',
             },
             resolve: {
                 mainFields: ['module', 'main'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1667,6 +1667,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jahia/javascript-modules-library@file:/Users/baptistegrimaud/Documents/code/jahia/BACKLOG-23366-javascript-modules/javascript-modules/javascript-modules-library/target/javascript-modules-library-0.0.1-SNAPSHOT.tgz::locator=luxe-jahia-demo%40workspace%3A.":
+  version: 0.0.1-SNAPSHOT
+  resolution: "@jahia/javascript-modules-library@file:/Users/baptistegrimaud/Documents/code/jahia/BACKLOG-23366-javascript-modules/javascript-modules/javascript-modules-library/target/javascript-modules-library-0.0.1-SNAPSHOT.tgz#/Users/baptistegrimaud/Documents/code/jahia/BACKLOG-23366-javascript-modules/javascript-modules/javascript-modules-library/target/javascript-modules-library-0.0.1-SNAPSHOT.tgz::hash=1197cc&locator=luxe-jahia-demo%40workspace%3A."
+  dependencies:
+    graphql: "npm:^16.0.1"
+    graphql-tag: "npm:^2.12.6"
+    i18next: "npm:^23.10.1"
+    prop-types: "npm:^15.8.1"
+    react: "npm:^18.2.0"
+    react-i18next: "npm:^14.1.0"
+  checksum: 10c0/58736754534726c4b558d499c80ba010da75ae6010376125b22682dfaf2ebde9e661b68e52bcd3b186120ca1da8730776cdf1c51b574beb5859bec27b0f3e5ae
+  languageName: node
+  linkType: hard
+
 "@jahia/js-server-core@npm:^0.0.15":
   version: 0.0.15
   resolution: "@jahia/js-server-core@npm:0.0.15"
@@ -6059,6 +6073,7 @@ __metadata:
     "@cyclonedx/webpack-plugin": "npm:^3.12.0"
     "@heroicons/react": "npm:^2.1.1"
     "@jahia/eslint-config": "npm:^2.1.2"
+    "@jahia/javascript-modules-library": /Users/baptistegrimaud/Documents/code/jahia/BACKLOG-23366-javascript-modules/javascript-modules/javascript-modules-library/target/javascript-modules-library-0.0.1-SNAPSHOT.tgz
     "@jahia/js-server-core": "npm:^0.0.15"
     "@jahia/scripts": "npm:^1.3.6"
     babel-loader: "npm:^8.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1667,9 +1667,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jahia/javascript-modules-library@file:/Users/baptistegrimaud/Documents/code/jahia/BACKLOG-23366-javascript-modules/javascript-modules/javascript-modules-library/target/javascript-modules-library-0.0.1-SNAPSHOT.tgz::locator=luxe-jahia-demo%40workspace%3A.":
-  version: 0.0.1-SNAPSHOT
-  resolution: "@jahia/javascript-modules-library@file:/Users/baptistegrimaud/Documents/code/jahia/BACKLOG-23366-javascript-modules/javascript-modules/javascript-modules-library/target/javascript-modules-library-0.0.1-SNAPSHOT.tgz#/Users/baptistegrimaud/Documents/code/jahia/BACKLOG-23366-javascript-modules/javascript-modules/javascript-modules-library/target/javascript-modules-library-0.0.1-SNAPSHOT.tgz::hash=1197cc&locator=luxe-jahia-demo%40workspace%3A."
+"@jahia/javascript-modules-library@npm:^0.0.4":
+  version: 0.0.4
+  resolution: "@jahia/javascript-modules-library@npm:0.0.4"
   dependencies:
     graphql: "npm:^16.0.1"
     graphql-tag: "npm:^2.12.6"
@@ -1677,21 +1677,7 @@ __metadata:
     prop-types: "npm:^15.8.1"
     react: "npm:^18.2.0"
     react-i18next: "npm:^14.1.0"
-  checksum: 10c0/58736754534726c4b558d499c80ba010da75ae6010376125b22682dfaf2ebde9e661b68e52bcd3b186120ca1da8730776cdf1c51b574beb5859bec27b0f3e5ae
-  languageName: node
-  linkType: hard
-
-"@jahia/js-server-core@npm:^0.0.15":
-  version: 0.0.15
-  resolution: "@jahia/js-server-core@npm:0.0.15"
-  dependencies:
-    graphql: "npm:^16.0.1"
-    graphql-tag: "npm:^2.12.6"
-    i18next: "npm:^23.10.1"
-    prop-types: "npm:^15.8.1"
-    react: "npm:^18.2.0"
-    react-i18next: "npm:^14.1.0"
-  checksum: 10c0/fc023eefaf8a46df6f33ae0195a70dd4a385b8c761e73cdad50774106debaa38ee702ba476150b0b59426875acdaf2126ddfb9717a8e867a0d2c186bfe54e60f
+  checksum: 10c0/0f84ecf855790f0ad477381664a7f99fc8ef45498718b750e3d90316abcc9f8e6b8f0dcda7d8349b9e40dc028a2c27c9763c99e3bbcd61e184a10cbf5b39a342
   languageName: node
   linkType: hard
 
@@ -6073,8 +6059,7 @@ __metadata:
     "@cyclonedx/webpack-plugin": "npm:^3.12.0"
     "@heroicons/react": "npm:^2.1.1"
     "@jahia/eslint-config": "npm:^2.1.2"
-    "@jahia/javascript-modules-library": /Users/baptistegrimaud/Documents/code/jahia/BACKLOG-23366-javascript-modules/javascript-modules/javascript-modules-library/target/javascript-modules-library-0.0.1-SNAPSHOT.tgz
-    "@jahia/js-server-core": "npm:^0.0.15"
+    "@jahia/javascript-modules-library": "npm:^0.0.4"
     "@jahia/scripts": "npm:^1.3.6"
     babel-loader: "npm:^8.2.3"
     babel-plugin-transform-react-remove-prop-types: "npm:^0.4.24"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23366

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Migrate from using `@jahia/js-server-core` to using `@jahia/javascript-modules-library` NPM package dependency, following changes in https://github.com/Jahia/javascript-modules/pull/1 (and the merge of the repositories https://github.com/Jahia/js-server-core and https://github.com/Jahia/npm-modules-engine/ into https://github.com/Jahia/javascript-modules).

**✅  Requirements before merging:**
- [x] https://github.com/Jahia/javascript-modules/pull/1 must be merged
- [x] a new version (0.0.4) of _javascript-modules-library_ must be released
- [x] the `package.json` must be updated to use the new released version
