### PR TITLE
BACKLOG-23514: fixed language switch not showing

### DIFF
--- a/src/server/layouts/MainLayout.jsx
+++ b/src/server/layouts/MainLayout.jsx
@@ -1,23 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {HtmlFooter, HtmlHead} from '../components';
-import {AbsoluteArea, AddResources} from '@jahia/javascript-modules-library';
-
-// Const navMenu = {
-//     name: 'navMenu',
-//     nodeType: 'luxe:navMenu',
-//     mixins: ['jmix:renderable'],
-//     properties: {
-//         base: 'home',
-//         maxDepth: '2',
-//         startLevel: '0',
-//         menuItemView: 'menuElement'
-//     }
-// };
+import {AbsoluteArea, AddResources, useServerContext} from '@jahia/javascript-modules-library';
 
 export const MainLayout = ({head, className, children}) => {
-    // Const {renderContext} = useServerContext();
-    // navMainArea.path = `/sites/${renderContext.getSite().getName()}`;
+    const {renderContext} = useServerContext();
+    const modulePath = renderContext.getURLGenerator().getCurrentModule();
     return (
         <>
             <HtmlHead>
@@ -29,7 +17,7 @@ export const MainLayout = ({head, className, children}) => {
                     {children}
                 </main>
                 <HtmlFooter/>
-                <AddResources type="javascript" resources="bootstrap.bundle.min.js"/>
+                <AddResources type="javascript" resources={modulePath + '/static/javascript/bootstrap.bundle.min.js'}/>
             </body>
         </>
     );

--- a/src/server/layouts/MainLayout.jsx
+++ b/src/server/layouts/MainLayout.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {HtmlFooter, HtmlHead} from '../components';
-import {AbsoluteArea, AddResources, useServerContext} from '@jahia/javascript-modules-library';
+import {AbsoluteArea, AddResources, useUrlBuilder} from '@jahia/javascript-modules-library';
 
 export const MainLayout = ({head, className, children}) => {
-    const {renderContext} = useServerContext();
-    const modulePath = renderContext.getURLGenerator().getCurrentModule();
+    const {buildStaticUrl} = useUrlBuilder();
+    const bootstrap = buildStaticUrl({assetPath: 'javascript/bootstrap.bundle.min.js'});
     return (
         <>
             <HtmlHead>
@@ -17,7 +17,7 @@ export const MainLayout = ({head, className, children}) => {
                     {children}
                 </main>
                 <HtmlFooter/>
-                <AddResources type="javascript" resources={modulePath + '/static/javascript/bootstrap.bundle.min.js'}/>
+                <AddResources type="javascript" resources={bootstrap}/>
             </body>
         </>
     );

--- a/src/server/views/navMenu/LanguageSwitcher.jsx
+++ b/src/server/views/navMenu/LanguageSwitcher.jsx
@@ -4,13 +4,12 @@ import clsx from 'clsx';
 
 const getSiteLanguageAsLocales = renderContext => {
     const site = renderContext.getSite();
-    switch (true) {
-        case renderContext.isLiveMode():
-            return site.getActiveLiveLanguagesAsLocales().toArray();
 
-        default:
-            return site.getLanguagesAsLocales().toArray();
+    if (renderContext.isLiveMode()) {
+        return site.getActiveLiveLanguagesAsLocales().toArray();
     }
+
+    return site.getLanguagesAsLocales().toArray();
 };
 
 export const LanguageSwitcher = () => {
@@ -32,7 +31,7 @@ export const LanguageSwitcher = () => {
             >
                 {currentLocaleName}
             </button>
-            <ul className="dropdown-menu">
+            <ul className="dropdown-menu dropdown-menu-end">
                 {siteLocales?.map(locale => {
                     const localeCode = locale.getLanguage();
                     const localeName = locale.getDisplayLanguage(locale);


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

The language switch is back, and won't go offscreen anymore!

![image](https://github.com/user-attachments/assets/5b6cf60d-604a-4b6b-a2cc-07586734e60a)

The language switcher was not showing because bootstrap was not properly loaded.

- `<AddResources>` does not trigger an error when not loading a resource
- The bootstrap.min.js file should not be versioned, it's webpack role to load dependencies from node_modules and move them to dist

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
...

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [x] Code maintainability: improved surrounding code

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
