### PR TITLE
BACKLOG-23346: prevent server files from being imported in client bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -111,9 +111,7 @@ module.exports = (env, argv) => {
                 // This plugin will raise an error if a client file tries to import a server file
                 {
                     apply(compiler) {
-                        const clientFiles = path.resolve(__dirname, 'src/client')
                         const serverFiles = path.resolve(__dirname, 'src/server')
-
                         compiler.options.resolve.plugins ??= []
                         compiler.options.resolve.plugins.push({
                             apply(resolver) {
@@ -121,7 +119,7 @@ module.exports = (env, argv) => {
                                     if (!request.request || !request.context.issuer)
                                        return callback()
                                     const resolved = path.resolve(path.dirname(request.context.issuer), request.request)
-                                    if (resolved.startsWith(serverFiles) && request.context.issuer.startsWith(clientFiles)) {
+                                    if (resolved.startsWith(serverFiles)) {
                                         return callback(new Error(
                                             'Cannot import server file\n\t' +
                                             resolved +


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Added a new WebPack plugin in the client build to prevent importing server files from 'src/client'.

It's a working PoC, tell me if you want a more robust approach

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
