### PR TITLE
QABACKLOG-1661: upgrade to jahia/cypress 4.0.0

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@jahia/cypress": "^3.17.7",
+    "@jahia/cypress": "^4.0.0",
     "@jahia/eslint-config": "^2.1.2",
     "@jahia/jahia-reporter": "^1.2.0",
     "@typescript-eslint/eslint-plugin": "^8.7.0",


### PR DESCRIPTION
https://jira.jahia.org/browse/QABACKLOG-1661
