### PR TITLE
chore: rename npm module to javascript module

### DIFF
--- a/.github/workflows/manual-run.yml
+++ b/.github/workflows/manual-run.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: jahia/jahia-modules-action/integration-tests@v2
         with:
           module_id: luxe-jahia-demo
-          testrail_project:  Demo Site NPM
+          testrail_project:  Demo Site Javascript Module
           tests_manifest: ${{ github.event.inputs.manifest }}
           jahia_image: ${{ github.event.inputs.jahia_image }}
           jahia_license: ${{ secrets.JAHIA_LICENSE_8X_FULL }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: jahia/jahia-modules-action/integration-tests@v2
         with:
           module_id: luxe-jahia-demo
-          testrail_project: Demo Site NPM
+          testrail_project: Demo Site Javascript Module
           tests_manifest: provisioning-manifest-snapshot.yml
           jahia_image: jahia/jahia-ee-dev:8-SNAPSHOT
           should_use_build_artifacts: false

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: corepack enable
-      - uses: jahia/jahia-modules-action/build-npm@v2
+      - uses: jahia/jahia-modules-action/build-javascript@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
@@ -53,7 +53,7 @@ jobs:
       - run: corepack enable
       - uses: jahia/jahia-modules-action/integration-tests@v2
         with:
-          testrail_project: Demo Site NPM
+          testrail_project: Demo Site Javascript Module
           tests_manifest: provisioning-manifest-build.yml
           jahia_image: jahia/jahia-ee-dev:8-SNAPSHOT
           jahia_license: ${{ secrets.JAHIA_LICENSE_8X_FULL }}

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup corepack
         run: corepack enable
-      - uses: jahia/jahia-modules-action/build-npm@v2
+      - uses: jahia/jahia-modules-action/build-javascript@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
@@ -68,7 +68,7 @@ jobs:
       - uses: jahia/jahia-modules-action/integration-tests@v2
         with:
           module_id: luxe-jahia-demo
-          testrail_project: Demo Site NPM
+          testrail_project: Demo Site Javascript Module
           tests_manifest: provisioning-manifest-build.yml
           jahia_image: jahia/jahia-ee-dev:8-SNAPSHOT
           jahia_license: ${{ secrets.JAHIA_LICENSE_8X_FULL }}
@@ -110,7 +110,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
-      - uses: jahia/jahia-modules-action/publish-npm@v2
+      - uses: jahia/jahia-modules-action/publish-javascript@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.GH_SSH_PRIVATE_KEY_JAHIACI }}
 
-      - uses: jahia/jahia-modules-action/release-npm@v2
+      - uses: jahia/jahia-modules-action/release-javascript@v2
         name: Release Module
         with:
           github_slug: Jahia/luxe-jahia-demo

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # luxe-jahia-demo
 
-A simple Jahia Javascript module created using the [Jahia Javascript modules starter project template](https://github.com/Jahia/npm-create-module)
+A simple Jahia Javascript module created using the [Jahia Javascript modules starter project template](https://github.com/Jahia/javascript-create-module)
 
 ## Configuration
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luxe-jahia-demo",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/tests/.env.example
+++ b/tests/.env.example
@@ -1,6 +1,6 @@
 JAHIA_VERSION=${JAHIA_VERSION:-8.2.0.0-SNAPSHOT}
 JAHIA_IMAGE=${JAHIA_IMAGE:-jahia/jahia-ee-dev:${JAHIA_VERSION}}
-TESTS_IMAGE=${TESTS_IMAGE:-jahia/npm-modules-engine:latest}
+TESTS_IMAGE=${TESTS_IMAGE:-jahia/luxe-demo-test:latest}
 MANIFEST=${MANIFEST:-provisioning-manifest-snapshot.yml}
 JAHIA_URL=${JAHIA_URL:-http://localhost:8080}
 SUPER_USER_PASSWORD=${SUPER_USER_PASSWORD:-root1234}

--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -1,4 +1,4 @@
 - installBundle:
-    - 'npm:mvn:org.jahia.modules.npm/luxe-jahia-demo/0.4.0-SNAPSHOT/tgz'
+    - 'js:mvn:org.example.modules.npm/luxe-jahia-demo/0.4.0-SNAPSHOT/tgz'
   autoStart: true
   uninstallPreviousVersion: true

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -164,7 +164,7 @@ module.exports = (env, argv) => {
                 path: buildOutput
             },
             externals: {
-                // Those libraries are supplied to webpack at runtime (by the npm-module-engine project), and are not packaged in the output bundle
+                // Those libraries are supplied to webpack at runtime (by the javascript-module-engine project), and are not packaged in the output bundle
                 '@jahia/javascript-modules-library': 'javascriptModulesLibraryBuilder.getLibrary()',
                 react: 'javascriptModulesLibraryBuilder.getSharedLibrary(\'react\')',
                 'react-i18next': 'javascriptModulesLibraryBuilder.getSharedLibrary(\'react-i18next\')',


### PR DESCRIPTION
Note that the `groupId` still has a reference to npm as we are not easily able to change the groupID of a jahia module. 