### PR TITLE
fix: suppress hydration warnings in edit mode

### DIFF
--- a/src/components/NavMenu/LanguageSwitcher.client.tsx
+++ b/src/components/NavMenu/LanguageSwitcher.client.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 export default function LanguageSwitcherClient({
   currentLocaleName,
   localesAndUrls,
+  mode,
 }: {
   currentLocaleName: string;
   localesAndUrls: {
@@ -11,11 +12,14 @@ export default function LanguageSwitcherClient({
     isCurrent: boolean;
     url: string;
   }[];
+  mode: string;
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownHandler = () => {
     setIsOpen((isOpen) => !isOpen);
   };
+  // suppress the hydration warnings in edit mode, as JContent performs some DOM manipulations, messing up with React hydration process
+  const suppressHydrationWarning = mode === "edit";
 
   return (
     <div className="dropdown">
@@ -24,6 +28,7 @@ export default function LanguageSwitcherClient({
         type="button"
         aria-expanded={isOpen}
         onClick={dropdownHandler}
+        suppressHydrationWarning={suppressHydrationWarning}
       >
         {currentLocaleName}
       </button>
@@ -38,6 +43,7 @@ export default function LanguageSwitcherClient({
                 href={url}
                 className={clsx("dropdown-item", "lux-capitalize", { active: isCurrent })}
                 aria-current={isCurrent}
+                suppressHydrationWarning={suppressHydrationWarning}
               >
                 {localeName}
               </a>

--- a/src/components/NavMenu/LanguageSwitcher.tsx
+++ b/src/components/NavMenu/LanguageSwitcher.tsx
@@ -11,6 +11,7 @@ export const LanguageSwitcher = () => {
   const currentLocale = currentResource.getLocale();
   const currentLocaleCode = currentLocale.toString();
   const currentLocaleName = currentLocale.getDisplayLanguage(currentLocale);
+  const mode = renderContext.getMode();
 
   const localesAndUrls = Object.entries(getSiteLocales()).map(([language, locale]) => {
     return {
@@ -23,7 +24,7 @@ export const LanguageSwitcher = () => {
   return (
     <HydrateInBrowser
       child={LanguageSwitcherClient}
-      props={{ currentLocaleName, localesAndUrls }}
+      props={{ currentLocaleName, localesAndUrls, mode }}
     />
   );
 };


### PR DESCRIPTION
### Description

Use the [React `suppressHydrationWarning` attribute](https://react.dev/reference/react-dom/client/hydrateRoot#suppressing-unavoidable-hydration-mismatch-errors) to suppress hydration warnings in edit mode.
The reason behind that is that the HTML generated server-side is altered after React rendered it. See [this comment](https://github.com/Jahia/luxe-jahia-demo/issues/220#issuecomment-2783979612) for additional details.


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
