### PR TITLE
fix: Missing navigation in preview mode

### DIFF
--- a/src/components/NavMenu/definition.cnd
+++ b/src/components/NavMenu/definition.cnd
@@ -1,4 +1,4 @@
-[luxe:navigationMenu] > jnt:content, mix:title
+[luxe:navigationMenu] > jnt:content, mix:title, jmix:droppableContent
  - brandText (string) i18n
  - brandImage (weakreference, picker[type='image']) < 'jmix:image'
  - brandImageMobile (weakreference, picker[type='image']) < 'jmix:image'

--- a/tests/cypress/e2e/previewMode.cy.ts
+++ b/tests/cypress/e2e/previewMode.cy.ts
@@ -1,0 +1,54 @@
+import { addNode, createSite, deleteSite, publishAndWaitJobEnding } from '@jahia/cypress'
+
+const siteKey = 'previewMode'
+
+describe('Preview mode', () => {
+    function createPage(pageName: string) {
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/home`,
+            name: pageName,
+            primaryNodeType: 'jnt:page',
+            properties: [
+                { name: 'jcr:title', value: pageName, language: 'en' },
+                { name: 'j:templateName', value: 'centered' },
+            ],
+        })
+    }
+    before('Create test data', () => {
+        cy.login()
+        createSite(siteKey, { templateSet: 'luxe-jahia-demo', locale: 'en', serverName: 'localhost' })
+        createPage('subPage1')
+        createPage('subPage2')
+        publishAndWaitJobEnding(`/sites/${siteKey}`)
+        cy.logout()
+    })
+
+    after('Delete test data', () => {
+        cy.login()
+        deleteSite(siteKey)
+        cy.logout()
+    })
+
+    function testNavigationExists(baseUrl: string = '') {
+        cy.visit(`${baseUrl}/sites/${siteKey}/home.html`)
+        cy.get('body nav #navbarSupportedContent ul').within(() => {
+            cy.get('li').should('have.length', 2)
+            cy.get(`li a[href="${baseUrl}/sites/${siteKey}/home/subPage1.html"]`)
+                .should('exist')
+                .and('have.text', 'subPage1')
+            cy.get(`li a[href="${baseUrl}/sites/${siteKey}/home/subPage2.html"]`)
+                .should('exist')
+                .and('have.text', 'subPage2')
+        })
+    }
+
+    it('the navigation menu should be visible in live mode', () => {
+        testNavigationExists()
+    })
+
+    it('the navigation menu should be visible in preview mode', () => {
+        cy.login()
+        testNavigationExists('/cms/render/default/en')
+        cy.logout()
+    })
+})


### PR DESCRIPTION
### Description

Use a virtual node to render the navigation in both live and preview modes.
This is temp workaround until Jahia 8.2.2.0 is released (with https://github.com/Jahia/jahia-private/pull/3688).

#### Tests
- [x] I've provided Unit and/or Integration Tests

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
