### PR TITLE
fix: oops I broken content picker icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"required-version": "8.2.1.0",
 		"module-type": "templatesSet",
 		"module-dependencies": "default,javascript-modules-engine",
-		"static-resources": "/dist/assets,/dist/client",
+		"static-resources": "/dist/assets,/dist/client,/icons",
 		"server": "dist/server/index.js",
 		"maven": {
 			"groupId": "org.jahia.modules.javascript",


### PR DESCRIPTION
### Description

This should fix 
<img width="315" alt="image" src="https://github.com/user-attachments/assets/306e64e7-d2d7-4a2e-9e7e-37bb091e7a70" />


### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
