### PR TITLE
chore: remove incorrect scm in pom

### DIFF
--- a/packages/prepackaged-site/pom.xml
+++ b/packages/prepackaged-site/pom.xml
@@ -13,13 +13,6 @@
   <packaging>bundle</packaging>
   <description>This is the custom module (Luxe pre-packaged website) for running on a Jahia server.</description>
 
-  <scm>
-    <connection>scm:git:git@github.com:Jahia/luxe-prepackaged-website.git</connection>
-    <developerConnection>scm:git:git@github.com:Jahia/luxe-prepackaged-website.git</developerConnection>
-    <url>https://github.com/Jahia/luxe-prepackaged-website</url>
-    <tag>HEAD</tag>
-  </scm>
-
   <properties>
     <jahia-module-type>system</jahia-module-type>
     <jahia-depends>default,luxe-jahia-demo</jahia-depends>


### PR DESCRIPTION
### Description

The repo is archived, inherit from the parent pom

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
