### PR TITLE
fix: sync package.json files from the monorepo root

### DIFF
--- a/packages/template-set/package.json
+++ b/packages/template-set/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "luxe-jahia-demo",
-	"version": "0.10.0-SNAPSHOT",
+	"version": "0.9.0-SNAPSHOT",
 	"license": "MIT",
 	"type": "module",
 	"files": [

--- a/packages/template-set/pom.xml
+++ b/packages/template-set/pom.xml
@@ -62,32 +62,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <!-- Keep package.json version in sync -->
-      <id>release-prepare</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.github.eirslett</groupId>
-            <artifactId>frontend-maven-plugin</artifactId>
-            <executions>
-              <!-- Keep the package.json in sync with the maven version -->
-              <execution>
-                <id>sync-version</id>
-                <phase>process-resources</phase>
-                <goals>
-                  <goal>yarn</goal>
-                </goals>
-                <configuration>
-                  <arguments>node ../../.m2/sync-version.js ${project.version}</arguments>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
                   <goal>yarn</goal>
                 </goals>
                 <configuration>
-                  <arguments>yarn workspaces foreach --all node ${basedir} ${project.version}</arguments>
+                  <arguments>yarn workspaces foreach --all node ${basedir}/.m2/sync-version.js ${project.version}</arguments>
                 </configuration>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,23 @@
               <message>chore(release): Prepare release ${project.version}</message>
             </configuration>
           </plugin>
+          <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <executions>
+              <!-- Keep all package.json in sync with the maven version -->
+              <execution>
+                <id>sync-version</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <arguments>yarn workspaces foreach --all node ${basedir} ${project.version}</arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
### Description

Since the installation of yarn and node is at the repo level and not per-project, all operations must be conducted from the root

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
