### PR TITLE
build: ensure package.json is committed during release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <artifactId>maven-scm-plugin</artifactId>
             <configuration>
-              <includes>yarn.lock</includes>
+              <includes>yarn.lock,**/package.json</includes>
               <message>chore(release): Prepare release ${project.version}</message>
             </configuration>
           </plugin>


### PR DESCRIPTION
### Description

Not sure if glob patterns work, but [the doc says so](https://maven.apache.org/scm/maven-scm-plugin/checkin-mojo.html#includes)

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
