### PR TITLE
fix: display HTML view from GQL call in search estate in case view is not rendered properly…

### DIFF
--- a/packages/template-set/src/commons/libs/jcrQueryBuilder/index.ts
+++ b/packages/template-set/src/commons/libs/jcrQueryBuilder/index.ts
@@ -199,10 +199,15 @@ export class JCRQueryBuilder {
 				json.data?.jcr?.nodesByQuery?.nodes ??
 				([] as Array<{ uuid: string; renderedContent?: { output: string } }>);
 
-			return nodes.map(({ uuid, renderedContent }) => ({
-				uuid,
-				html: renderedContent?.output ?? "",
-			}));
+			return nodes.map(({ uuid, renderedContent }) => {
+				if (!renderedContent?.output) {
+					console.warn(`No rendered content for node ${uuid}`);
+				}
+				return {
+					uuid,
+					html: renderedContent?.output ?? "",
+				};
+			});
 		} finally {
 			clearTimeout(id);
 		}

--- a/packages/template-set/src/components/SearchEstate/results.server.tsx
+++ b/packages/template-set/src/components/SearchEstate/results.server.tsx
@@ -89,8 +89,11 @@ jahiaComponent(
 
 		const gqlNodes: GqlNode[] = gqlContents?.data?.jcr?.nodesByQuery?.nodes;
 		const nodes: RenderNodeProps[] = gqlNodes?.map((node) => {
+			if (!node.renderedContent?.output) {
+				console.warn(`No rendered content for node ${node.uuid}`);
+			}
 			return {
-				html: node.renderedContent.output,
+				html: node.renderedContent?.output || "",
 				uuid: node.uuid,
 			};
 		});


### PR DESCRIPTION
… view is not render

### Description
...

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
