### PR TITLE
test: fix manual run workflow

### DIFF
--- a/.github/workflows/manual-run.yml
+++ b/.github/workflows/manual-run.yml
@@ -19,10 +19,23 @@ jobs:
     uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
     secrets: inherit
     with:
-      jahia_image: Jahia/jahia-ee-dev:8-SNAPSHOT
+      jahia_image: ${{ github.event.inputs.jahia_image }}
       module_id: luxe-jahia-demo
       should_skip_testrail: true
       pagerduty_skip_notification: true
       provisioning_manifest: ${{ github.event.inputs.manifest }}
       artifact_prefix: luxe
       module_branch: ${{ github.ref }}
+
+  test-report:
+    needs: integration-tests
+    runs-on: self-hosted
+    steps:
+      - name: Test Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+          name: Tests Report (Standalone)
+          path: tests/artifacts/results/xml_reports/**/*.xml
+          reporter: java-junit
+          fail-on-error: 'false'

--- a/.github/workflows/manual-run.yml
+++ b/.github/workflows/manual-run.yml
@@ -26,16 +26,3 @@ jobs:
       provisioning_manifest: ${{ github.event.inputs.manifest }}
       artifact_prefix: luxe
       module_branch: ${{ github.ref }}
-
-  test-report:
-    needs: integration-tests
-    runs-on: self-hosted
-    steps:
-      - name: Test Report
-        uses: dorny/test-reporter@v1
-        if: success() || failure()
-        with:
-          name: Tests Report (Standalone)
-          path: tests/artifacts/results/xml_reports/**/*.xml
-          reporter: java-junit
-          fail-on-error: 'false'

--- a/.github/workflows/nightly-SN.yml
+++ b/.github/workflows/nightly-SN.yml
@@ -13,7 +13,7 @@ jobs:
       jahia_image: ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT
       module_id: luxe-jahia-demo
       testrail_project: Demo Site Javascript Module
-      pagerduty_incident_service: keepicker-JahiaSN
+      pagerduty_incident_service: luxe-jahia-demo-JahiaSN
       provisioning_manifest: provisioning-manifest-snapshot.yml
       artifact_prefix: luxe
       module_branch: ${{ github.ref }}


### PR DESCRIPTION
### Description
Try to fix manual run workflow by
- using a parameter instead of default jahia image
- adding a report path

Also fixed `pagerduty_incident_service` for nightly snapshot.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
