### PR TITLE
test: add testrail project name to manual run workflow

### DIFF
--- a/.github/workflows/manual-run.yml
+++ b/.github/workflows/manual-run.yml
@@ -21,6 +21,7 @@ jobs:
     with:
       jahia_image: ${{ github.event.inputs.jahia_image }}
       module_id: luxe-jahia-demo
+      testrail_project: Demo Site Javascript Module
       should_skip_testrail: true
       pagerduty_skip_notification: true
       provisioning_manifest: ${{ github.event.inputs.manifest }}


### PR DESCRIPTION
### Description
Add testrail project name otherwise the run seem to be failing with : 
```
Get all testrail projects
   ›   Error: Failed to find project named ''
  There was an issue processing the command (Error). It failed at: "2025-10-06T11:45:51.083Z"
Error: ENOENT: no such file or directory, stat '/opt/actions-runner/_work/luxe-jahia-demo/luxe-jahia-demo/tests/artifacts/results/testrail_link'
```

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
