### PR TITLE
fix(template-set): use a static graphql query

### DIFF
--- a/packages/template-set/src/components/Form/Login/default.server.tsx
+++ b/packages/template-set/src/components/Form/Login/default.server.tsx
@@ -23,8 +23,7 @@ jahiaComponent(
 	) => {
 		const isLoggedIn = renderContext.isLoggedIn();
 
-		// @ts-expect-error getName() is not available in getUser
-		const userHydrated = renderContext.getUser().getName();
+		const userHydrated = renderContext.getUser().getUsername();
 
 		// URL management, usage of buildEndpointUrl ensure urls are correct (vanity, url rewriting, webapp context, etc.)
 		const urls = {

--- a/packages/template-set/src/components/SearchEstate/results.server.tsx
+++ b/packages/template-set/src/components/SearchEstate/results.server.tsx
@@ -1,5 +1,5 @@
 import { Island, jahiaComponent, server, useGQLQuery } from "@jahia/javascript-modules-library";
-import { gqlNodesQueryString, JCRQueryBuilder } from "~/commons/libs/jcrQueryBuilder";
+import { gqlNodesQuery, JCRQueryBuilder } from "~/commons/libs/jcrQueryBuilder";
 import type {
 	Constraint,
 	GqlNode,
@@ -74,16 +74,13 @@ jahiaComponent(
 		server.render.addCacheDependency({ flushOnPathMatchingRegexp: cacheDependency }, renderContext);
 
 		const gqlContents = useGQLQuery({
-			query: gqlNodesQueryString({
-				isRenderEnabled: true,
-				limit: builderConfig.limit,
-				offset: 0,
-			}),
+			query: gqlNodesQuery,
 			variables: {
 				workspace: builderConfig.workspace,
 				query: jcrQuery,
 				language: builderConfig.language,
 				view: builderConfig.subNodeView,
+				limit: builderConfig.limit,
 			},
 		});
 


### PR DESCRIPTION
### Description

We should use gql vars instead of concatenation. This PR changes that, and removes unused branches.

This is preliminary work for introducing typed gql documents in Luxe: typing requires static documents.

--> Follow up PR: #350 

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
