### PR TITLE
fix(template-set): use default ck toolbars

### DIFF
--- a/packages/template-set/src/components/Estate/definition.cnd
+++ b/packages/template-set/src/components/Estate/definition.cnd
@@ -1,6 +1,6 @@
 [luxe:estate] > jnt:content, jmix:mainResource, luxemix:queryContent
  - title (string) primary i18n mandatory
-// - description (string,richtext[ckeditor.toolbar='Light']) i18n mandatory
+// - description (string,richtext) i18n mandatory
  - description (string,richtext) i18n mandatory
  - price (long) mandatory
  - images (weakreference, picker[type='image']) multiple mandatory < 'jmix:image'

--- a/packages/template-set/src/components/Realtor/definition.cnd
+++ b/packages/template-set/src/components/Realtor/definition.cnd
@@ -3,7 +3,7 @@
  - firstName (string) mandatory
  - lastName (string) primary mandatory
  - jobPosition (string,choicelist[resourceBundle]) = 'junior' mandatory < 'junior', 'senior', 'director'
- - description (string,richtext[ckeditor.toolbar='Light']) i18n mandatory
+ - description (string,richtext) i18n mandatory
  - image (weakreference, picker[type='image']) < 'jmix:image'
  - animate (weakreference, picker[type='video']) < 'jnt:file'
  - languages (string,choicelist[resourceBundle]) = 'fr' multiple autocreated mandatory < 'fr', 'en', 'de', 'es'

--- a/packages/template-set/src/components/TextIllustrated/definition.cnd
+++ b/packages/template-set/src/components/TextIllustrated/definition.cnd
@@ -1,5 +1,5 @@
 [luxe:textIllustrated] > jnt:content, luxemix:luxeLayout, luxemix:cta
  - title (string) primary i18n mandatory
- - text (string,richtext[ckeditor.toolbar='Basic']) i18n mandatory
+ - text (string,richtext) i18n mandatory
  - image (weakreference, picker[type='image']) mandatory < jmix:image
  - arrangement (string,choicelist[resourceBundle]) = 'left' autocreated < 'right', 'left'


### PR DESCRIPTION
### Description

CK5 uses different toolbar names, this is no longer relevant. Use the default config for now.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
