### PR TITLE
refactor(template-set): use upcoming jsm 1.1 features

### DIFF
--- a/packages/template-set/package.json
+++ b/packages/template-set/package.json
@@ -50,7 +50,7 @@
 	"jahia": {
 		"required-version": "8.2.1.0",
 		"module-type": "templatesSet",
-		"module-dependencies": "default,javascript-modules-engine=[1,2)",
+		"module-dependencies": "default,javascript-modules-engine=[1.1,2)",
 		"static-resources": "/dist/assets,/dist/client,/icons,/images",
 		"server": "dist/server/index.js",
 		"maven": {

--- a/packages/template-set/src/components/SearchEstate/results.server.tsx
+++ b/packages/template-set/src/components/SearchEstate/results.server.tsx
@@ -1,5 +1,3 @@
-import { print } from "@0no-co/graphql.web";
-import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import { Island, jahiaComponent, server, useGQLQuery } from "@jahia/javascript-modules-library";
 import { fetchEstate } from "./graphql.ts";
 import SearchEstateClient from "./SearchEstate.client.tsx";
@@ -42,19 +40,7 @@ jahiaComponent(
 			language: currentNode.getLanguage(),
 			params,
 		};
-		const results = fetchEstate(
-			// TODO: in JSM 1.1.0 we can use useGQLQuery directly
-			({
-				query,
-				variables,
-				operationName,
-			}: {
-				query: TypedDocumentNode;
-				variables?: Record<string, any>;
-				operationName?: string;
-			}) => useGQLQuery({ query: print(query), variables, operationName }),
-			config,
-		);
+		const results = fetchEstate(useGQLQuery, config);
 
 		return (
 			<Island


### PR DESCRIPTION
### Description

In the upcoming JSM 1.1, `useGQLQuery` supports GraphQL documents

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
