### PR TITLE
fix: restrict search results to the current site

### DIFF
--- a/packages/template-set/src/components/SearchEstate/graphql.ts
+++ b/packages/template-set/src/components/SearchEstate/graphql.ts
@@ -100,7 +100,7 @@ export function fetchEstate(
 			workspace: config.workspace,
 			query: {
 				// Restrict search to the site root path
-				paths: [config.root],
+				paths: [config.rootPath],
 				// Complete the query with type and ordering
 				nodeType: "luxe:estate",
 				ordering: { property: "price", orderType: "DESC" },

--- a/packages/template-set/src/components/SearchEstate/results.server.tsx
+++ b/packages/template-set/src/components/SearchEstate/results.server.tsx
@@ -37,7 +37,7 @@ jahiaComponent(
 		// All the data required to fetch the estate nodes
 		const config: QueryConfig = {
 			workspace: renderContext.isLiveMode() ? "LIVE" : "EDIT",
-			root: renderContext.getSite().getPath(),
+			rootPath: renderContext.getSite().getPath(),
 			language: currentNode.getLanguage(),
 			params,
 		};

--- a/packages/template-set/src/components/SearchEstate/types.ts
+++ b/packages/template-set/src/components/SearchEstate/types.ts
@@ -1,6 +1,6 @@
 export type QueryConfig = {
 	workspace: "EDIT" | "LIVE";
-	root: string;
+	rootPath: string;
 	language: string;
 	params: Record<string, string[]>;
 };


### PR DESCRIPTION
### Description

Closes #369 by using the `paths` GraphQL param, set to `renderContext.getSite().getPath()`

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
