### PR TITLE
fix: remove linkchecker from site.properties to be compatible with…

### DIFF
--- a/packages/prepackaged-site/src/main/luxe-prepackaged-website/site.properties
+++ b/packages/prepackaged-site/src/main/luxe-prepackaged-website/site.properties
@@ -4,7 +4,6 @@ sitetitle=Demo Site Luxe
 description=Simple demo website built by the Jahia team
 siteservernamealiases=
 language.fr.mandatory=false
-installedModules.3=linkchecker
 installedModules.4=siteSettings
 installedModules.1=luxe-jahia-demo
 sitekey=luxe


### PR DESCRIPTION
bug fix remove linkchecker from site.properties to be compatible with the jahia open core docker image

### Description
...

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
