### PR TITLE
fix(template-set): add missing cnd namespaces

### DIFF
--- a/packages/template-set/settings/definitions.cnd
+++ b/packages/template-set/settings/definitions.cnd
@@ -1,3 +1,6 @@
+<nt = 'http://www.jcp.org/jcr/nt/1.0'>
+<mix = 'http://www.jcp.org/jcr/mix/1.0'>
+<jcr = 'http://www.jcp.org/jcr/1.0'>
 <j = 'http://www.jahia.org/jahia/1.0'>
 <jnt = 'http://www.jahia.org/jahia/nt/1.0'>
 <jmix = 'http://www.jahia.org/jahia/mix/1.0'>
@@ -20,5 +23,3 @@
 // This mixin is used to define which content is allowed to be returned by the JcrQuery content type. Add this mixin
 // to your content type to be able to select it from the "type" props of a JcrQuery content
 [luxemix:queryContent] mixin
-
-


### PR DESCRIPTION
### Description

Fixes these warnings

```
2026-01-28 17:20:30,362: WARN  [JahiaCndReader] - definitions415253830426598140.cnd: Name mix:title is missing namespace URI definition !
```

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
