### PR TITLE
fix: add missing namespace declaration for mix

### DIFF
--- a/packages/template-set/settings/definitions.cnd
+++ b/packages/template-set/settings/definitions.cnd
@@ -1,3 +1,4 @@
+<mix = 'http://www.jcp.org/jcr/mix/1.0'>
 <j = 'http://www.jahia.org/jahia/1.0'>
 <jnt = 'http://www.jahia.org/jahia/nt/1.0'>
 <jmix = 'http://www.jahia.org/jahia/mix/1.0'>


### PR DESCRIPTION
### Description
Add missing namepsace declaration for `mix`

this will remove warnings at module install:
```
2026-01-28 17:20:30,361: WARN  [JahiaCndReader] - definitions415253830426598140.cnd: Name mix:title is missing namespace URI definition !
2026-01-28 17:20:30,362: WARN  [JahiaCndReader] - definitions415253830426598140.cnd: Name mix:title is missing namespace URI definition !
2026-01-28 17:20:30,362: WARN  [JahiaCndReader] - definitions415253830426598140.cnd: Name mix:title is missing namespace URI definition !
2026-01-28 17:20:30,362: WARN  [JahiaCndReader] - definitions415253830426598140.cnd: Name mix:title is missing namespace URI definition !
2026-01-28 17:20:30,363: WARN  [JahiaCndReader] - definitions415253830426598140.cnd: Name mix:title is missing namespace URI definition !
2026-01-28 17:20:30,363: WARN  [JahiaCndReader] - definitions415253830426598140.cnd: Name mix:title is missing namespace URI definition !
```
### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
