### PR TITLE
fix: Properly render i18n translations client-side

### DIFF
--- a/packages/template-set/src/commons/Contact.client.tsx
+++ b/packages/template-set/src/commons/Contact.client.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
 import { HeadingSection } from "design-system";
-import { t } from "i18next";
 import classes from "./Contact.client.module.css";
 import { Dialog } from "design-system";
 import ContactFormClient from "~/components/Form/Contact/Contact.client";
+import { useTranslation } from "react-i18next";
 
 export interface ContactProps {
 	addresses: { address: string; id: string }[];
@@ -22,6 +22,7 @@ export default function ContactClient({
 	feedbackMsg = "",
 	contextMode = "default",
 }: ContactProps) {
+	const { t } = useTranslation();
 	const [isOpen, setIsOpen] = useState(false);
 	return (
 		<>

--- a/packages/template-set/src/components/Form/Contact/Contact.client.tsx
+++ b/packages/template-set/src/components/Form/Contact/Contact.client.tsx
@@ -1,10 +1,10 @@
 import { useMemo, useState } from "react";
-import { t } from "i18next";
 import ContactFormClient from "./ContactForm.client";
 import type { EmptyObject, FeedbackProps, MsgPropsProps } from "./types";
 import classes from "~/components/Form/Contact/Contact.client.module.css";
 import alert from "~/templates/css/alert.module.css";
 import clsx from "clsx";
+import { useTranslation } from "react-i18next";
 
 // This code runs when Jahia DxP is configured.
 // If available, it will prefill the form with the user's context.
@@ -20,6 +20,7 @@ export default function ContactClient({
 	feedbackMsg: string;
 	mode: string;
 }) {
+	const { t } = useTranslation();
 	const [feedback, setFeedback] = useState<FeedbackProps>({ show: false, msgProps: {} });
 	const [unknownError, setUnknownError] = useState<boolean>(false);
 

--- a/packages/template-set/src/components/Form/Contact/ContactForm.client.tsx
+++ b/packages/template-set/src/components/Form/Contact/ContactForm.client.tsx
@@ -1,10 +1,10 @@
 import { type Dispatch, type SetStateAction, useState } from "react";
-import { t } from "i18next";
 import { submitContact } from "./utils.client";
 import type { EmptyObject, FeedbackProps, MsgPropsProps } from "./types";
 import classes from "~/components/Form/Contact/ContactForm.client.module.css";
 import form from "~/templates/css/form.module.css";
 import clsx from "clsx";
+import { useTranslation } from "react-i18next";
 
 interface ContactFormProps {
 	target?: string;
@@ -23,6 +23,7 @@ const ContactFormClient = ({
 	setUnknownError,
 	mode,
 }: ContactFormProps) => {
+	const { t } = useTranslation();
 	const [firstName, setFirstName] = useState(prefill.firstName);
 	const [lastName, setLastName] = useState(prefill.lastName);
 	const [email, setEmail] = useState(prefill.email);

--- a/packages/template-set/src/components/Form/Login/Login.client.tsx
+++ b/packages/template-set/src/components/Form/Login/Login.client.tsx
@@ -1,12 +1,12 @@
 import { type MouseEvent, useState } from "react";
 import LoginFormClient from "./LoginForm.client.js";
 import WorkspaceNavigationClient from "./WorkspaceNavigation.client.js";
-import { t } from "i18next";
 import type { JahiaUrlsProps, LoginPersonaProps } from "./types";
 import classes from "~/components/Form/Login/Login.client.module.css";
 import alert from "~/templates/css/alert.module.css";
 import clsx from "clsx";
 import { Dialog } from "design-system";
+import { useTranslation } from "react-i18next";
 
 interface LoginClientProps {
 	isLoggedIn: boolean;
@@ -29,6 +29,7 @@ export default function LoginClient({
 	siteKey,
 	persona,
 }: LoginClientProps) {
+	const { t } = useTranslation();
 	const [user, setUser] = useState(userHydrated);
 	const [loggedIn, setLoggedIn] = useState(isLoggedIn);
 	const [isOpen, setIsOpen] = useState(false);

--- a/packages/template-set/src/components/Form/Login/LoginCard.client.tsx
+++ b/packages/template-set/src/components/Form/Login/LoginCard.client.tsx
@@ -1,8 +1,8 @@
 import { login } from "./utils.client";
-import { t } from "i18next";
 import type { LoginCommonProps } from "./types";
 import classes from "~/components/Form/Login/LoginCard.client.module.css";
 import { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 interface LoginCardClientProps {
 	username: string;
@@ -32,6 +32,7 @@ export const LoginCardClient = ({
 	loginCommonProps,
 	...props
 }: LoginCardClientProps) => {
+	const { t } = useTranslation();
 	const handleClick = () =>
 		login({
 			username,

--- a/packages/template-set/src/components/Form/Login/LoginForm.client.tsx
+++ b/packages/template-set/src/components/Form/Login/LoginForm.client.tsx
@@ -1,12 +1,12 @@
 import { type Dispatch, type SetStateAction, useState } from "react";
 import LoginCardClient from "./LoginCard.client";
-import { t } from "i18next";
 import { login } from "./utils.client";
 import type { LoginCommonProps, LoginPersonaProps } from "./types";
 import classes from "~/components/Form/Login/LoginForm.client.module.css";
 import alert from "~/templates/css/alert.module.css";
 import form from "~/templates/css/form.module.css";
 import clsx from "clsx";
+import { useTranslation } from "react-i18next";
 
 interface LoginFormClientProps {
 	loginUrl: string;
@@ -25,6 +25,7 @@ const LoginFormClient = ({
 	isShowRememberMe = true,
 	persona,
 }: LoginFormClientProps) => {
+	const { t } = useTranslation();
 	const [incorrectLogin, setIncorrectLogin] = useState(false);
 	const [unknownError, setUnknownError] = useState(false);
 	const [username, setUsername] = useState("");

--- a/packages/template-set/src/components/Form/Login/WorkspaceNavigation.client.tsx
+++ b/packages/template-set/src/components/Form/Login/WorkspaceNavigation.client.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
-import { t } from "i18next";
 import type { JahiaUrlsProps } from "./types";
+import { useTranslation } from "react-i18next";
 
 const hasPermission = async (gqlUrl: string, permission: string, path: string) => {
 	const response = await fetch(gqlUrl, {
@@ -38,6 +38,7 @@ const WorkspaceNavigationClient = ({
 	mode: string;
 	nodePath: string;
 }) => {
+	const { t } = useTranslation();
 	const [isLoading, setIsLoading] = useState(true);
 	const [hasJContentPermission, setHasJContentPermission] = useState(false);
 

--- a/packages/template-set/src/components/SearchEstate/SearchEstateForm.client.tsx
+++ b/packages/template-set/src/components/SearchEstate/SearchEstateForm.client.tsx
@@ -1,8 +1,8 @@
 import { Form, MultiSelectTags } from "design-system";
-import { MapPinIcon, HomeIcon, RoomIcon } from "design-system/Icons";
+import { HomeIcon, MapPinIcon, RoomIcon } from "design-system/Icons";
 import clsx from "clsx";
 import classes from "./SearchEstateForm.client.module.css";
-import { t } from "i18next";
+import { useTranslation } from "react-i18next";
 
 type Props = {
 	action?: string;
@@ -19,6 +19,7 @@ export default function SearchEstateFormClient({
 	className,
 	style,
 }: Props) {
+	const { t } = useTranslation();
 	const estateTypeTranslation = {
 		house: t("estate.type.house"),
 		apartment: t("estate.type.apartment"),


### PR DESCRIPTION
Closes https://github.com/Jahia/javascript-modules/issues/317.
Similar to https://github.com/Jahia/user-password-authentication/pull/139.

### Description

Following the change in https://github.com/Jahia/javascript-modules/pull/629, use [`useTranslation()` hook](https://react.i18next.com/latest/usetranslation-hook) to correctly render i18n translations client-side.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
