### PR TITLE
fix: convert Layout footer to Jahia component for i18n support

### DIFF
--- a/packages/template-set/settings/definitions.cnd
+++ b/packages/template-set/settings/definitions.cnd
@@ -7,6 +7,7 @@
 
 <luxe = 'http://www.jahia.org/jahia/demo/luxe/nt/1.0'>
 <luxemix = 'http://www.jahia.org/jahia/demo/luxe/mix/1.0'>
+<luxetemplate = 'http://www.jahia.org/jahia/demo/luxe/template/1.0'>
 
 // Defining the content types is similar to defining a data model: once deployed, you cannot change the type of a property.
 // If you need to do changes during the development phase, it is possible to remove the definitions from the tools:

--- a/packages/template-set/src/commons/Map/geocodeAddress.ts
+++ b/packages/template-set/src/commons/Map/geocodeAddress.ts
@@ -1,4 +1,4 @@
-import { t } from "i18next";
+import { useTranslation } from "react-i18next";
 
 const cache = new Map<string, { lat: number; lng: number }>();
 
@@ -25,5 +25,6 @@ export const geocodeAddress = async (address: string): Promise<{ lat: number; ln
 
 		return result;
 	}
+	const { t } = useTranslation();
 	throw new Error(t("maps.error.addressNotFound"));
 };

--- a/packages/template-set/src/components/Agency/default.server.tsx
+++ b/packages/template-set/src/components/Agency/default.server.tsx
@@ -4,13 +4,13 @@ import {
 	jahiaComponent,
 	server,
 } from "@jahia/javascript-modules-library";
-import { t } from "i18next";
 import type { AgencyProps } from "./types";
 import classes from "./default.module.css";
 import placeholder from "/static/img/agency-placeholder.jpg";
 import { imageNodeToImgProps } from "~/commons/libs/imageNodeToProps";
 import { Image } from "design-system";
 import type { ImgHTMLAttributes } from "react";
+import { useTranslation } from "react-i18next";
 
 jahiaComponent(
 	{
@@ -19,6 +19,7 @@ jahiaComponent(
 		componentType: "view",
 	},
 	({ name, address, phone, image: imageNode }: AgencyProps, { currentNode, renderContext }) => {
+		const { t } = useTranslation();
 		let imageProps: ImgHTMLAttributes<HTMLImageElement> = {
 			src: buildModuleFileUrl(placeholder),
 		};

--- a/packages/template-set/src/components/Agency/fullPage.server.tsx
+++ b/packages/template-set/src/components/Agency/fullPage.server.tsx
@@ -11,7 +11,6 @@ import {
 import type { RenderContext } from "org.jahia.services.render";
 import type { JCRNodeWrapper } from "org.jahia.services.content";
 
-import { t } from "i18next";
 import ContactClient from "~/commons/Contact.client";
 import type { AgencyProps } from "./types";
 import type { RealtorProps } from "~/components/Realtor/types";
@@ -30,6 +29,7 @@ import {
 	type ListRowProps,
 } from "design-system";
 import type { ImgHTMLAttributes } from "react";
+import { useTranslation } from "react-i18next";
 
 const MAX_ESTATE = 6;
 
@@ -76,6 +76,7 @@ jahiaComponent(
 		}: AgencyProps,
 		{ currentNode, renderContext },
 	) => {
+		const { t } = useTranslation();
 		const currentNodePath = currentNode.getPath();
 		const contextMode = renderContext.getMode();
 

--- a/packages/template-set/src/components/BlogPost/card.server.tsx
+++ b/packages/template-set/src/components/BlogPost/card.server.tsx
@@ -4,13 +4,13 @@ import {
 	jahiaComponent,
 	server,
 } from "@jahia/javascript-modules-library";
-import { t } from "i18next";
 import type { BlogPostProps } from "./types";
 import classes from "./card.module.css";
 import placeholder from "/static/img/img-placeholder.jpg";
 import { imageNodeToImgProps } from "~/commons/libs/imageNodeToProps";
 import { Image } from "design-system";
 import type { ImgHTMLAttributes } from "react";
+import { useTranslation } from "react-i18next";
 
 jahiaComponent(
 	{
@@ -20,6 +20,7 @@ jahiaComponent(
 		componentType: "view",
 	},
 	({ title, subtitle, image: imageNode }: BlogPostProps, { currentNode, renderContext }) => {
+		const { t } = useTranslation();
 		let imageProps: ImgHTMLAttributes<HTMLImageElement> = {
 			src: buildModuleFileUrl(placeholder),
 		};

--- a/packages/template-set/src/components/BlogPost/default.server.tsx
+++ b/packages/template-set/src/components/BlogPost/default.server.tsx
@@ -4,13 +4,13 @@ import {
 	jahiaComponent,
 	server,
 } from "@jahia/javascript-modules-library";
-import { t } from "i18next";
 import type { BlogPostProps } from "./types";
 import classes from "./default.module.css";
 import placeholder from "/static/img/img-placeholder.jpg";
 import { imageNodeToImgProps } from "~/commons/libs/imageNodeToProps";
 import { Image } from "design-system";
 import type { ImgHTMLAttributes } from "react";
+import { useTranslation } from "react-i18next";
 
 jahiaComponent(
 	{
@@ -19,6 +19,7 @@ jahiaComponent(
 		componentType: "view",
 	},
 	({ title, subtitle, image: imageNode }: BlogPostProps, { currentNode, renderContext }) => {
+		const { t } = useTranslation();
 		let imageProps: ImgHTMLAttributes<HTMLImageElement> = {
 			src: buildModuleFileUrl(placeholder),
 		};

--- a/packages/template-set/src/components/BlogPost/fullPage.server.tsx
+++ b/packages/template-set/src/components/BlogPost/fullPage.server.tsx
@@ -4,13 +4,13 @@ import {
 	Render,
 	server,
 } from "@jahia/javascript-modules-library";
-import { t } from "i18next";
 import type { BlogPostProps } from "./types.js";
 import classes from "./fullPage.module.css";
 import placeholder from "/static/img/img-placeholder.jpg";
 import { Col, Figure, HeadingSection, Image, Row, Section } from "design-system";
 import { imageNodeToImgProps } from "~/commons/libs/imageNodeToProps";
 import type { ImgHTMLAttributes } from "react";
+import { useTranslation } from "react-i18next";
 
 /* eslint-disable @eslint-react/dom/no-dangerously-set-innerhtml */
 jahiaComponent(
@@ -32,6 +32,7 @@ jahiaComponent(
 		}: BlogPostProps,
 		{ currentNode, renderContext },
 	) => {
+		const { t } = useTranslation();
 		// Image: placeholder by default; override when a real node exists
 		let imageProps: ImgHTMLAttributes<HTMLImageElement> = {
 			src: buildModuleFileUrl(placeholder),

--- a/packages/template-set/src/components/BlogPost/tile.server.tsx
+++ b/packages/template-set/src/components/BlogPost/tile.server.tsx
@@ -4,13 +4,13 @@ import {
 	jahiaComponent,
 	server,
 } from "@jahia/javascript-modules-library";
-import { t } from "i18next";
 import type { BlogPostProps } from "./types";
 import classes from "./tile.module.css";
 import placeholder from "/static/img/img-placeholder.jpg";
 import { imageNodeToImgProps } from "~/commons/libs/imageNodeToProps";
 import { Image } from "design-system";
 import type { ImgHTMLAttributes } from "react";
+import { useTranslation } from "react-i18next";
 
 jahiaComponent(
 	{
@@ -20,6 +20,7 @@ jahiaComponent(
 		componentType: "view",
 	},
 	({ title, image: imageNode }: BlogPostProps, { currentNode, renderContext }) => {
+		const { t } = useTranslation();
 		// Image: placeholder by default; override when a real node exists
 		let imageProps: ImgHTMLAttributes<HTMLImageElement> = {
 			src: buildModuleFileUrl(placeholder),

--- a/packages/template-set/src/components/Estate/default.server.tsx
+++ b/packages/template-set/src/components/Estate/default.server.tsx
@@ -5,11 +5,11 @@ import {
 	server,
 } from "@jahia/javascript-modules-library";
 import { ClickableCard, Image } from "design-system";
-import { t } from "i18next";
 import type { ImgHTMLAttributes } from "react";
 import { imageNodeToImgProps } from "~/commons/libs/imageNodeToProps";
 import type { EstateProps } from "./types";
 import placeholder from "/static/img/img-placeholder.jpg";
+import { useTranslation } from "react-i18next";
 
 jahiaComponent(
 	{
@@ -21,6 +21,7 @@ jahiaComponent(
 		{ title, price, images, surface, bedrooms }: EstateProps,
 		{ currentNode, currentResource, renderContext },
 	) => {
+		const { t } = useTranslation();
 		const locale = currentResource.getLocale().getLanguage();
 
 		// Image: placeholder by default; override when a real node exists

--- a/packages/template-set/src/components/Estate/fullPage.server.tsx
+++ b/packages/template-set/src/components/Estate/fullPage.server.tsx
@@ -5,13 +5,13 @@ import {
 	server,
 } from "@jahia/javascript-modules-library";
 import GalleryClient from "~/commons/Gallery.client.tsx";
-import { t } from "i18next";
 import type { EstateProps } from "./types.js";
 import { CheckIcon } from "design-system/Icons";
 import classes from "./fullPage.module.css";
 import placeholder from "/static/img/img-placeholder.jpg";
 import { imageNodeToImgProps } from "~/commons/libs/imageNodeToProps";
 import { Col, List, type ListRowProps, PageTitle, Row, Section } from "design-system";
+import { useTranslation } from "react-i18next";
 
 /* eslint-disable @eslint-react/dom/no-dangerously-set-innerhtml */
 jahiaComponent(
@@ -36,6 +36,7 @@ jahiaComponent(
 		}: EstateProps,
 		{ currentResource, renderContext },
 	) => {
+		const { t } = useTranslation();
 		const locale = currentResource.getLocale().getLanguage();
 
 		const galleryImages = images

--- a/packages/template-set/src/components/JcrQuery/default.server.tsx
+++ b/packages/template-set/src/components/JcrQuery/default.server.tsx
@@ -7,10 +7,10 @@ import {
 import type { JCRNodeWrapper } from "org.jahia.services.content";
 import classes from "./default.module.css";
 import alert from "~/templates/css/alert.module.css";
-import { t } from "i18next";
 import { buildQuery } from "./utils";
 import type { JcrQueryProps } from "./types";
 import { Col, HeadingSection, Row } from "design-system";
+import { useTranslation } from "react-i18next";
 
 jahiaComponent(
 	{
@@ -33,6 +33,7 @@ jahiaComponent(
 		}: JcrQueryProps,
 		{ currentNode, renderContext },
 	) => {
+		const { t } = useTranslation();
 		const { jcrQuery, warn } = buildQuery({
 			luxeQuery: {
 				"jcr:title": title,

--- a/packages/template-set/src/components/JcrQuery/inline.server.tsx
+++ b/packages/template-set/src/components/JcrQuery/inline.server.tsx
@@ -5,11 +5,11 @@ import {
 	server,
 } from "@jahia/javascript-modules-library";
 import type { JCRNodeWrapper } from "org.jahia.services.content";
-import { t } from "i18next";
 import { buildQuery } from "./utils";
 import type { JcrQueryProps } from "./types";
 import alert from "~/templates/css/alert.module.css";
 import { HeadingSection } from "design-system";
+import { useTranslation } from "react-i18next";
 
 jahiaComponent(
 	{
@@ -33,6 +33,7 @@ jahiaComponent(
 		}: JcrQueryProps,
 		{ currentNode, renderContext },
 	) => {
+		const { t } = useTranslation();
 		const { jcrQuery, warn } = buildQuery({
 			luxeQuery: {
 				"jcr:title": title,

--- a/packages/template-set/src/components/JcrQuery/tilesGrid.server.tsx
+++ b/packages/template-set/src/components/JcrQuery/tilesGrid.server.tsx
@@ -5,13 +5,13 @@ import {
 	server,
 } from "@jahia/javascript-modules-library";
 import type { JCRNodeWrapper } from "org.jahia.services.content";
-import { t } from "i18next";
 import { buildQuery } from "./utils";
 import clsx from "clsx";
 import type { JcrQueryProps } from "./types";
 import alert from "~/templates/css/alert.module.css";
 import grid from "design-system/Grid/styles.module.css";
 import { Col, HeadingSection, Row } from "design-system";
+import { useTranslation } from "react-i18next";
 
 jahiaComponent(
 	{
@@ -35,6 +35,7 @@ jahiaComponent(
 		}: JcrQueryProps,
 		{ currentNode, renderContext },
 	) => {
+		const { t } = useTranslation();
 		const { jcrQuery, warn } = buildQuery({
 			luxeQuery: {
 				"jcr:title": title,

--- a/packages/template-set/src/components/Realtor/animate.server.tsx
+++ b/packages/template-set/src/components/Realtor/animate.server.tsx
@@ -5,12 +5,12 @@ import {
 	jahiaComponent,
 	server,
 } from "@jahia/javascript-modules-library";
-import { t } from "i18next";
 import type { RealtorProps } from "./types.js";
 import placeholder from "/static/img/agent-placeholder.jpg";
 import AnimateClient from "~/components/Realtor/Animate.client";
 import { imageNodeToImgProps } from "~/commons/libs/imageNodeToProps";
 import type { ImgHTMLAttributes } from "react";
+import { useTranslation } from "react-i18next";
 
 jahiaComponent(
 	{
@@ -23,6 +23,7 @@ jahiaComponent(
 		{ firstName, lastName, jobPosition, image: imageNode, animate: videoNode }: RealtorProps,
 		{ currentNode, renderContext },
 	) => {
+		const { t } = useTranslation();
 		let imageProps: ImgHTMLAttributes<HTMLImageElement> = {
 			src: buildModuleFileUrl(placeholder),
 		};

--- a/packages/template-set/src/components/Realtor/default.server.tsx
+++ b/packages/template-set/src/components/Realtor/default.server.tsx
@@ -4,13 +4,13 @@ import {
 	jahiaComponent,
 	server,
 } from "@jahia/javascript-modules-library";
-import { t } from "i18next";
 import type { RealtorProps } from "./types.js";
 import classes from "./default.module.css";
 import placeholder from "/static/img/agent-placeholder.jpg";
 import { imageNodeToImgProps } from "~/commons/libs/imageNodeToProps";
 import { Image } from "design-system";
 import type { ImgHTMLAttributes } from "react";
+import { useTranslation } from "react-i18next";
 
 jahiaComponent(
 	{
@@ -22,6 +22,7 @@ jahiaComponent(
 		{ firstName, lastName, jobPosition, image: imageNode }: RealtorProps,
 		{ currentNode, renderContext },
 	) => {
+		const { t } = useTranslation();
 		let imageProps: ImgHTMLAttributes<HTMLImageElement> = {
 			src: buildModuleFileUrl(placeholder),
 		};

--- a/packages/template-set/src/components/Realtor/fullPage.server.tsx
+++ b/packages/template-set/src/components/Realtor/fullPage.server.tsx
@@ -8,7 +8,6 @@ import {
 	server,
 } from "@jahia/javascript-modules-library";
 import type { JCRNodeWrapper } from "org.jahia.services.content";
-import { t } from "i18next";
 import type { RealtorProps } from "./types.js";
 import classes from "./fullPage.module.css";
 import placeholder from "/static/img/agent-placeholder.jpg";
@@ -25,6 +24,7 @@ import {
 	type ListRowProps,
 } from "design-system";
 import type { ImgHTMLAttributes } from "react";
+import { useTranslation } from "react-i18next";
 
 const MAX_ESTATE = 6;
 
@@ -48,6 +48,7 @@ jahiaComponent(
 		}: RealtorProps,
 		{ currentNode, renderContext },
 	) => {
+		const { t } = useTranslation();
 		const contextMode = renderContext.getMode();
 		const refBy = currentNode.getWeakReferences();
 		const refByNode: JCRNodeWrapper[] = [];

--- a/packages/template-set/src/components/SearchEstate/SearchResults.tsx
+++ b/packages/template-set/src/components/SearchEstate/SearchResults.tsx
@@ -1,8 +1,8 @@
 import clsx from "clsx";
 import { ClickableCard, Col, Image, ProgressiveList } from "design-system";
-import { t } from "i18next";
 import classes from "./SearchResults.module.css";
 import type { Estate } from "./types.ts";
+import { useTranslation } from "react-i18next";
 
 export default function SearchResultsClient({
 	results,
@@ -13,6 +13,7 @@ export default function SearchResultsClient({
 	isEditMode: boolean;
 	locale: string;
 }) {
+	const { t } = useTranslation();
 	if (results.length === 0) {
 		return (
 			<Col>

--- a/packages/template-set/src/templates/Footer/default.module.css
+++ b/packages/template-set/src/templates/Footer/default.module.css
@@ -1,0 +1,26 @@
+.list {
+	composes: listUnstyled from "~/templates/css/global.module.css";
+}
+
+.capitalize {
+	composes: capitalize from "~/templates/css/global.module.css";
+}
+
+.fullTextCapitalize {
+	display: inline-block;
+	text-transform: capitalize;
+}
+
+.disclaimer {
+	font-size: 12px;
+	opacity: 0.6;
+	padding-bottom: 1rem;
+
+	a {
+		font-size: inherit;
+	}
+}
+
+.copyright {
+	text-align: right;
+}

--- a/packages/template-set/src/templates/Footer/default.server.tsx
+++ b/packages/template-set/src/templates/Footer/default.server.tsx
@@ -1,0 +1,84 @@
+import { AbsoluteArea, jahiaComponent, Render } from "@jahia/javascript-modules-library";
+import { useTranslation } from "react-i18next";
+import { Col, Row, Section } from "design-system";
+import grid from "design-system/Grid/styles.module.css";
+import classes from "./default.module.css";
+
+jahiaComponent(
+	{
+		nodeType: "luxetemplate:footer",
+		name: "default",
+		componentType: "view",
+	},
+	(_, { renderContext }) => {
+		const { t } = useTranslation();
+		return (
+			<Section component="footer">
+				<Row>
+					<Col className={grid.col_4}>
+						<h5 className={classes.capitalize}>{t("footer.resources")}</h5>
+						<ul className={classes.list}>
+							<li>
+								<a
+									className={classes.fullTextCapitalize}
+									href="https://academy.jahia.com/home"
+									target="_blank"
+									rel="noreferrer"
+								>
+									{t("footer.academy")}
+								</a>
+							</li>
+							<li>
+								<a
+									className={classes.capitalize}
+									href="https://academy.jahia.com/get-started"
+									target="_blank"
+									rel="noreferrer"
+								>
+									{t("footer.tutorial")}
+								</a>
+							</li>
+							<li>
+								<a
+									className={classes.capitalize}
+									href="https://github.com/Jahia/luxe-jahia-demo/"
+									target="_blank"
+									rel="noreferrer"
+								>
+									{t("footer.sourceCode")}
+								</a>
+							</li>
+						</ul>
+					</Col>
+					<Col className={grid.col_5}>
+						<Render content={loginForm} />
+					</Col>
+				</Row>
+				<Row className={classes.disclaimer}>
+					<Col>
+						{/* numberOfItems={4} */}
+						<AbsoluteArea
+							name="footerNavLinkArea"
+							parent={renderContext.getSite().getHome()}
+							nodeType="jnt:linkList"
+							allowedNodeTypes={["jnt:nodeLink", "jnt:externalLink"]}
+						/>
+					</Col>
+					<Col className={classes.copyright}>
+						<span>{t("footer.copyright", { currentDate: new Date().getFullYear() })}</span>
+					</Col>
+				</Row>
+			</Section>
+		);
+	},
+);
+
+// The login form is implemented as static content.
+// It will be added to the footer and cannot be modified by Jahia contributors.
+const loginForm = {
+	name: "loginForm",
+	nodeType: "luxe:loginForm",
+	properties: {
+		"j:displayRememberMeButton": "true",
+	},
+};

--- a/packages/template-set/src/templates/Footer/definition.cnd
+++ b/packages/template-set/src/templates/Footer/definition.cnd
@@ -1,0 +1,1 @@
+[luxetemplate:footer] > jnt:content

--- a/packages/template-set/src/templates/Layout.module.css
+++ b/packages/template-set/src/templates/Layout.module.css
@@ -20,33 +20,6 @@ footer {
 	}
 }
 
-.list {
-	composes: listUnstyled from "~/templates/css/global.module.css";
-}
-
-.capitalize {
-	composes: capitalize from "~/templates/css/global.module.css";
-}
-
-.fullTextCapitalize {
-	display: inline-block;
-	text-transform: capitalize;
-}
-
-.disclaimer {
-	font-size: 12px;
-	opacity: 0.6;
-	padding-bottom: 1rem;
-
-	a {
-		font-size: inherit;
-	}
-}
-
-.copyright {
-	text-align: right;
-}
-
 .skipLink {
 	position: absolute;
 	clip: rect(0 0 0 0);

--- a/packages/template-set/src/templates/Layout.tsx
+++ b/packages/template-set/src/templates/Layout.tsx
@@ -1,19 +1,24 @@
 import type { JSX, ReactNode } from "react";
 import {
-	AbsoluteArea,
 	AddResources,
 	buildModuleFileUrl,
 	getNodeProps,
 	Render,
 	useServerContext,
 } from "@jahia/javascript-modules-library";
-import { t } from "i18next";
 import "./css/global.module.css";
 import type { JCRNodeWrapper } from "org.jahia.services.content";
 import classes from "./Layout.module.css";
-import grid from "design-system/Grid/styles.module.css";
 import favicon from "/static/favicon-32x32.png";
-import { Col, Row, Section } from "design-system";
+import { useTranslation } from "react-i18next";
+
+// Use a Jahia component to render the footer template,
+// so it can benefit from the I18nextProvider (injected by the JavaScript Modules Engine)
+// and rely on useTranslation() with the correct namespace.
+const templateFooter = {
+	name: "templateFooter",
+	nodeType: "luxetemplate:footer",
+};
 
 /**
  * Layout : Places 'children' in an html page.
@@ -38,17 +43,24 @@ export const Layout = ({
 	head?: ReactNode;
 	className?: string;
 	children: ReactNode;
-}): JSX.Element => (
-	<>
-		<HtmlHead>{head}</HtmlHead>
-		<body>
-			<a href="#main" className={classes.skipLink}>{t("skipToContent")}</a>
-			<VirtualNavMenu />
-			<main id="main" className={className}>{children}</main>
-			<HtmlFooter />
-		</body>
-	</>
-);
+}): JSX.Element => {
+	const { t } = useTranslation();
+	return (
+		<>
+			<HtmlHead>{head}</HtmlHead>
+			<body>
+				<a href="#main" className={classes.skipLink}>
+					{t("skipToContent")}
+				</a>
+				<VirtualNavMenu />
+				<main id="main" className={className}>
+					{children}
+				</main>
+				<Render content={templateFooter} />
+			</body>
+		</>
+	);
+};
 
 /**
  * HtmlHead
@@ -108,84 +120,6 @@ const VirtualNavMenu = (): JSX.Element => {
 				],
 			}}
 		/>
-	);
-};
-
-// The login form is implemented as static content.
-// It will be added to the footer and cannot be modified by Jahia contributors.
-const loginForm = {
-	name: "loginForm",
-	nodeType: "luxe:loginForm",
-	properties: {
-		"j:displayRememberMeButton": "true",
-	},
-};
-
-/**
- * HtmlFooter
- * @param className
- * @returns {JSX.Element}
- * @constructor
- */
-const HtmlFooter = ({ className }: { className?: string }): JSX.Element => {
-	const { renderContext } = useServerContext();
-	return (
-		<Section component="footer" className={className}>
-			<Row>
-				<Col className={grid.col_4}>
-					<h5 className={classes.capitalize}>{t("footer.resources")}</h5>
-					<ul className={classes.list}>
-						<li>
-							<a
-								className={classes.fullTextCapitalize}
-								href="https://academy.jahia.com/home"
-								target="_blank"
-								rel="noreferrer"
-							>
-								{t("footer.academy")}
-							</a>
-						</li>
-						<li>
-							<a
-								className={classes.capitalize}
-								href="https://academy.jahia.com/get-started"
-								target="_blank"
-								rel="noreferrer"
-							>
-								{t("footer.tutorial")}
-							</a>
-						</li>
-						<li>
-							<a
-								className={classes.capitalize}
-								href="https://github.com/Jahia/luxe-jahia-demo/"
-								target="_blank"
-								rel="noreferrer"
-							>
-								{t("footer.sourceCode")}
-							</a>
-						</li>
-					</ul>
-				</Col>
-				<Col className={grid.col_5}>
-					<Render content={loginForm} />
-				</Col>
-			</Row>
-			<Row className={classes.disclaimer}>
-				<Col>
-					{/* numberOfItems={4} */}
-					<AbsoluteArea
-						name="footerNavLinkArea"
-						parent={renderContext.getSite().getHome()}
-						nodeType="jnt:linkList"
-						allowedNodeTypes={["jnt:nodeLink", "jnt:externalLink"]}
-					/>
-				</Col>
-				<Col className={classes.copyright}>
-					<span>{t("footer.copyright", { currentDate: new Date().getFullYear() })}</span>
-				</Col>
-			</Row>
-		</Section>
 	);
 };
 


### PR DESCRIPTION
Fixes https://github.com/Jahia/javascript-modules/issues/317.

### Description
#### Problem

Translations were not rendering properly when components from different Jahia modules were present on the same page—only translation keys were displayed (e.g., "Footer.Academy" instead of "Jahia Academy").

#### Root cause

The footer in `Layout.tsx` was a plain React component without access to the `I18nextProvider` injected by the JavaScript Modules Engine, preventing proper i18n namespace resolution.
The `I18nextProvider` is defined at https://github.com/Jahia/javascript-modules/blob/main/javascript-modules-engine/src/server/init-react.tsx#L42.

#### Solution

The fix is to extract the footer into a new Jahia component (`luxetemplate:footer`) that receives the i18n context.
Note that this component is **not** a `jmix:droppableContent`, hence does not appear as a content type choice when adding a new content from jContent.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
