### PR TITLE
fix: Use useTranslation() hook server-side for proper i18n SSR

### DIFF
--- a/packages/template-set/src/commons/Map/geocodeAddress.ts
+++ b/packages/template-set/src/commons/Map/geocodeAddress.ts
@@ -1,4 +1,4 @@
-import { t } from "i18next";
+import { useTranslation } from "react-i18next";
 
 const cache = new Map<string, { lat: number; lng: number }>();
 
@@ -25,5 +25,6 @@ export const geocodeAddress = async (address: string): Promise<{ lat: number; ln
 
 		return result;
 	}
+	const { t } = useTranslation();
 	throw new Error(t("maps.error.addressNotFound"));
 };

--- a/packages/template-set/src/components/Agency/default.server.tsx
+++ b/packages/template-set/src/components/Agency/default.server.tsx
@@ -4,13 +4,13 @@ import {
 	jahiaComponent,
 	server,
 } from "@jahia/javascript-modules-library";
-import { t } from "i18next";
 import type { AgencyProps } from "./types";
 import classes from "./default.module.css";
 import placeholder from "/static/img/agency-placeholder.jpg";
 import { imageNodeToImgProps } from "~/commons/libs/imageNodeToProps";
 import { Image } from "design-system";
 import type { ImgHTMLAttributes } from "react";
+import { useTranslation } from "react-i18next";
 
 jahiaComponent(
 	{
@@ -19,6 +19,7 @@ jahiaComponent(
 		componentType: "view",
 	},
 	({ name, address, phone, image: imageNode }: AgencyProps, { currentNode, renderContext }) => {
+		const { t } = useTranslation();
 		let imageProps: ImgHTMLAttributes<HTMLImageElement> = {
 			src: buildModuleFileUrl(placeholder),
 		};

--- a/packages/template-set/src/components/Agency/fullPage.server.tsx
+++ b/packages/template-set/src/components/Agency/fullPage.server.tsx
@@ -11,7 +11,6 @@ import {
 import type { RenderContext } from "org.jahia.services.render";
 import type { JCRNodeWrapper } from "org.jahia.services.content";
 
-import { t } from "i18next";
 import ContactClient from "~/commons/Contact.client";
 import type { AgencyProps } from "./types";
 import type { RealtorProps } from "~/components/Realtor/types";
@@ -30,6 +29,7 @@ import {
 	type ListRowProps,
 } from "design-system";
 import type { ImgHTMLAttributes } from "react";
+import { useTranslation } from "react-i18next";
 
 const MAX_ESTATE = 6;
 
@@ -76,6 +76,7 @@ jahiaComponent(
 		}: AgencyProps,
 		{ currentNode, renderContext },
 	) => {
+		const { t } = useTranslation();
 		const currentNodePath = currentNode.getPath();
 		const contextMode = renderContext.getMode();
 

--- a/packages/template-set/src/components/BlogPost/card.server.tsx
+++ b/packages/template-set/src/components/BlogPost/card.server.tsx
@@ -4,13 +4,13 @@ import {
 	jahiaComponent,
 	server,
 } from "@jahia/javascript-modules-library";
-import { t } from "i18next";
 import type { BlogPostProps } from "./types";
 import classes from "./card.module.css";
 import placeholder from "/static/img/img-placeholder.jpg";
 import { imageNodeToImgProps } from "~/commons/libs/imageNodeToProps";
 import { Image } from "design-system";
 import type { ImgHTMLAttributes } from "react";
+import { useTranslation } from "react-i18next";
 
 jahiaComponent(
 	{
@@ -20,6 +20,7 @@ jahiaComponent(
 		componentType: "view",
 	},
 	({ title, subtitle, image: imageNode }: BlogPostProps, { currentNode, renderContext }) => {
+		const { t } = useTranslation();
 		let imageProps: ImgHTMLAttributes<HTMLImageElement> = {
 			src: buildModuleFileUrl(placeholder),
 		};

--- a/packages/template-set/src/components/BlogPost/default.server.tsx
+++ b/packages/template-set/src/components/BlogPost/default.server.tsx
@@ -4,13 +4,13 @@ import {
 	jahiaComponent,
 	server,
 } from "@jahia/javascript-modules-library";
-import { t } from "i18next";
 import type { BlogPostProps } from "./types";
 import classes from "./default.module.css";
 import placeholder from "/static/img/img-placeholder.jpg";
 import { imageNodeToImgProps } from "~/commons/libs/imageNodeToProps";
 import { Image } from "design-system";
 import type { ImgHTMLAttributes } from "react";
+import { useTranslation } from "react-i18next";
 
 jahiaComponent(
 	{
@@ -19,6 +19,7 @@ jahiaComponent(
 		componentType: "view",
 	},
 	({ title, subtitle, image: imageNode }: BlogPostProps, { currentNode, renderContext }) => {
+		const { t } = useTranslation();
 		let imageProps: ImgHTMLAttributes<HTMLImageElement> = {
 			src: buildModuleFileUrl(placeholder),
 		};

--- a/packages/template-set/src/components/BlogPost/fullPage.server.tsx
+++ b/packages/template-set/src/components/BlogPost/fullPage.server.tsx
@@ -4,13 +4,13 @@ import {
 	Render,
 	server,
 } from "@jahia/javascript-modules-library";
-import { t } from "i18next";
 import type { BlogPostProps } from "./types.js";
 import classes from "./fullPage.module.css";
 import placeholder from "/static/img/img-placeholder.jpg";
 import { Col, Figure, HeadingSection, Image, Row, Section } from "design-system";
 import { imageNodeToImgProps } from "~/commons/libs/imageNodeToProps";
 import type { ImgHTMLAttributes } from "react";
+import { useTranslation } from "react-i18next";
 
 /* eslint-disable @eslint-react/dom/no-dangerously-set-innerhtml */
 jahiaComponent(
@@ -32,6 +32,7 @@ jahiaComponent(
 		}: BlogPostProps,
 		{ currentNode, renderContext },
 	) => {
+		const { t } = useTranslation();
 		// Image: placeholder by default; override when a real node exists
 		let imageProps: ImgHTMLAttributes<HTMLImageElement> = {
 			src: buildModuleFileUrl(placeholder),

--- a/packages/template-set/src/components/BlogPost/tile.server.tsx
+++ b/packages/template-set/src/components/BlogPost/tile.server.tsx
@@ -4,13 +4,13 @@ import {
 	jahiaComponent,
 	server,
 } from "@jahia/javascript-modules-library";
-import { t } from "i18next";
 import type { BlogPostProps } from "./types";
 import classes from "./tile.module.css";
 import placeholder from "/static/img/img-placeholder.jpg";
 import { imageNodeToImgProps } from "~/commons/libs/imageNodeToProps";
 import { Image } from "design-system";
 import type { ImgHTMLAttributes } from "react";
+import { useTranslation } from "react-i18next";
 
 jahiaComponent(
 	{
@@ -20,6 +20,7 @@ jahiaComponent(
 		componentType: "view",
 	},
 	({ title, image: imageNode }: BlogPostProps, { currentNode, renderContext }) => {
+		const { t } = useTranslation();
 		// Image: placeholder by default; override when a real node exists
 		let imageProps: ImgHTMLAttributes<HTMLImageElement> = {
 			src: buildModuleFileUrl(placeholder),

--- a/packages/template-set/src/components/Estate/default.server.tsx
+++ b/packages/template-set/src/components/Estate/default.server.tsx
@@ -5,11 +5,11 @@ import {
 	server,
 } from "@jahia/javascript-modules-library";
 import { ClickableCard, Image } from "design-system";
-import { t } from "i18next";
 import type { ImgHTMLAttributes } from "react";
 import { imageNodeToImgProps } from "~/commons/libs/imageNodeToProps";
 import type { EstateProps } from "./types";
 import placeholder from "/static/img/img-placeholder.jpg";
+import { useTranslation } from "react-i18next";
 
 jahiaComponent(
 	{
@@ -21,6 +21,7 @@ jahiaComponent(
 		{ title, price, images, surface, bedrooms }: EstateProps,
 		{ currentNode, currentResource, renderContext },
 	) => {
+		const { t } = useTranslation();
 		const locale = currentResource.getLocale().getLanguage();
 
 		// Image: placeholder by default; override when a real node exists

--- a/packages/template-set/src/components/Estate/fullPage.server.tsx
+++ b/packages/template-set/src/components/Estate/fullPage.server.tsx
@@ -5,13 +5,13 @@ import {
 	server,
 } from "@jahia/javascript-modules-library";
 import GalleryClient from "~/commons/Gallery.client.tsx";
-import { t } from "i18next";
 import type { EstateProps } from "./types.js";
 import { CheckIcon } from "design-system/Icons";
 import classes from "./fullPage.module.css";
 import placeholder from "/static/img/img-placeholder.jpg";
 import { imageNodeToImgProps } from "~/commons/libs/imageNodeToProps";
 import { Col, List, type ListRowProps, PageTitle, Row, Section } from "design-system";
+import { useTranslation } from "react-i18next";
 
 /* eslint-disable @eslint-react/dom/no-dangerously-set-innerhtml */
 jahiaComponent(
@@ -36,6 +36,7 @@ jahiaComponent(
 		}: EstateProps,
 		{ currentResource, renderContext },
 	) => {
+		const { t } = useTranslation();
 		const locale = currentResource.getLocale().getLanguage();
 
 		const galleryImages = images

--- a/packages/template-set/src/components/JcrQuery/default.server.tsx
+++ b/packages/template-set/src/components/JcrQuery/default.server.tsx
@@ -7,10 +7,10 @@ import {
 import type { JCRNodeWrapper } from "org.jahia.services.content";
 import classes from "./default.module.css";
 import alert from "~/templates/css/alert.module.css";
-import { t } from "i18next";
 import { buildQuery } from "./utils";
 import type { JcrQueryProps } from "./types";
 import { Col, HeadingSection, Row } from "design-system";
+import { useTranslation } from "react-i18next";
 
 jahiaComponent(
 	{
@@ -33,6 +33,7 @@ jahiaComponent(
 		}: JcrQueryProps,
 		{ currentNode, renderContext },
 	) => {
+		const { t } = useTranslation();
 		const { jcrQuery, warn } = buildQuery({
 			luxeQuery: {
 				"jcr:title": title,

--- a/packages/template-set/src/components/JcrQuery/inline.server.tsx
+++ b/packages/template-set/src/components/JcrQuery/inline.server.tsx
@@ -5,11 +5,11 @@ import {
 	server,
 } from "@jahia/javascript-modules-library";
 import type { JCRNodeWrapper } from "org.jahia.services.content";
-import { t } from "i18next";
 import { buildQuery } from "./utils";
 import type { JcrQueryProps } from "./types";
 import alert from "~/templates/css/alert.module.css";
 import { HeadingSection } from "design-system";
+import { useTranslation } from "react-i18next";
 
 jahiaComponent(
 	{
@@ -33,6 +33,7 @@ jahiaComponent(
 		}: JcrQueryProps,
 		{ currentNode, renderContext },
 	) => {
+		const { t } = useTranslation();
 		const { jcrQuery, warn } = buildQuery({
 			luxeQuery: {
 				"jcr:title": title,

--- a/packages/template-set/src/components/JcrQuery/tilesGrid.server.tsx
+++ b/packages/template-set/src/components/JcrQuery/tilesGrid.server.tsx
@@ -5,13 +5,13 @@ import {
 	server,
 } from "@jahia/javascript-modules-library";
 import type { JCRNodeWrapper } from "org.jahia.services.content";
-import { t } from "i18next";
 import { buildQuery } from "./utils";
 import clsx from "clsx";
 import type { JcrQueryProps } from "./types";
 import alert from "~/templates/css/alert.module.css";
 import grid from "design-system/Grid/styles.module.css";
 import { Col, HeadingSection, Row } from "design-system";
+import { useTranslation } from "react-i18next";
 
 jahiaComponent(
 	{
@@ -35,6 +35,7 @@ jahiaComponent(
 		}: JcrQueryProps,
 		{ currentNode, renderContext },
 	) => {
+		const { t } = useTranslation();
 		const { jcrQuery, warn } = buildQuery({
 			luxeQuery: {
 				"jcr:title": title,

--- a/packages/template-set/src/components/Realtor/animate.server.tsx
+++ b/packages/template-set/src/components/Realtor/animate.server.tsx
@@ -5,12 +5,12 @@ import {
 	jahiaComponent,
 	server,
 } from "@jahia/javascript-modules-library";
-import { t } from "i18next";
 import type { RealtorProps } from "./types.js";
 import placeholder from "/static/img/agent-placeholder.jpg";
 import AnimateClient from "~/components/Realtor/Animate.client";
 import { imageNodeToImgProps } from "~/commons/libs/imageNodeToProps";
 import type { ImgHTMLAttributes } from "react";
+import { useTranslation } from "react-i18next";
 
 jahiaComponent(
 	{
@@ -23,6 +23,7 @@ jahiaComponent(
 		{ firstName, lastName, jobPosition, image: imageNode, animate: videoNode }: RealtorProps,
 		{ currentNode, renderContext },
 	) => {
+		const { t } = useTranslation();
 		let imageProps: ImgHTMLAttributes<HTMLImageElement> = {
 			src: buildModuleFileUrl(placeholder),
 		};

--- a/packages/template-set/src/components/Realtor/default.server.tsx
+++ b/packages/template-set/src/components/Realtor/default.server.tsx
@@ -4,13 +4,13 @@ import {
 	jahiaComponent,
 	server,
 } from "@jahia/javascript-modules-library";
-import { t } from "i18next";
 import type { RealtorProps } from "./types.js";
 import classes from "./default.module.css";
 import placeholder from "/static/img/agent-placeholder.jpg";
 import { imageNodeToImgProps } from "~/commons/libs/imageNodeToProps";
 import { Image } from "design-system";
 import type { ImgHTMLAttributes } from "react";
+import { useTranslation } from "react-i18next";
 
 jahiaComponent(
 	{
@@ -22,6 +22,7 @@ jahiaComponent(
 		{ firstName, lastName, jobPosition, image: imageNode }: RealtorProps,
 		{ currentNode, renderContext },
 	) => {
+		const { t } = useTranslation();
 		let imageProps: ImgHTMLAttributes<HTMLImageElement> = {
 			src: buildModuleFileUrl(placeholder),
 		};

--- a/packages/template-set/src/components/Realtor/fullPage.server.tsx
+++ b/packages/template-set/src/components/Realtor/fullPage.server.tsx
@@ -8,7 +8,6 @@ import {
 	server,
 } from "@jahia/javascript-modules-library";
 import type { JCRNodeWrapper } from "org.jahia.services.content";
-import { t } from "i18next";
 import type { RealtorProps } from "./types.js";
 import classes from "./fullPage.module.css";
 import placeholder from "/static/img/agent-placeholder.jpg";
@@ -25,6 +24,7 @@ import {
 	type ListRowProps,
 } from "design-system";
 import type { ImgHTMLAttributes } from "react";
+import { useTranslation } from "react-i18next";
 
 const MAX_ESTATE = 6;
 
@@ -48,6 +48,7 @@ jahiaComponent(
 		}: RealtorProps,
 		{ currentNode, renderContext },
 	) => {
+		const { t } = useTranslation();
 		const contextMode = renderContext.getMode();
 		const refBy = currentNode.getWeakReferences();
 		const refByNode: JCRNodeWrapper[] = [];

--- a/packages/template-set/src/components/SearchEstate/SearchResults.tsx
+++ b/packages/template-set/src/components/SearchEstate/SearchResults.tsx
@@ -1,8 +1,8 @@
 import clsx from "clsx";
 import { ClickableCard, Col, Image, ProgressiveList } from "design-system";
-import { t } from "i18next";
 import classes from "./SearchResults.module.css";
 import type { Estate } from "./types.ts";
+import { useTranslation } from "react-i18next";
 
 export default function SearchResultsClient({
 	results,
@@ -13,6 +13,7 @@ export default function SearchResultsClient({
 	isEditMode: boolean;
 	locale: string;
 }) {
+	const { t } = useTranslation();
 	if (results.length === 0) {
 		return (
 			<Col>

--- a/packages/template-set/src/templates/Layout.tsx
+++ b/packages/template-set/src/templates/Layout.tsx
@@ -7,13 +7,13 @@ import {
 	Render,
 	useServerContext,
 } from "@jahia/javascript-modules-library";
-import { t } from "i18next";
 import "./css/global.module.css";
 import type { JCRNodeWrapper } from "org.jahia.services.content";
 import classes from "./Layout.module.css";
 import grid from "design-system/Grid/styles.module.css";
 import favicon from "/static/favicon-32x32.png";
 import { Col, Row, Section } from "design-system";
+import { useTranslation } from "react-i18next";
 
 /**
  * Layout : Places 'children' in an html page.
@@ -38,17 +38,24 @@ export const Layout = ({
 	head?: ReactNode;
 	className?: string;
 	children: ReactNode;
-}): JSX.Element => (
-	<>
-		<HtmlHead>{head}</HtmlHead>
-		<body>
-			<a href="#main" className={classes.skipLink}>{t("skipToContent")}</a>
-			<VirtualNavMenu />
-			<main id="main" className={className}>{children}</main>
-			<HtmlFooter />
-		</body>
-	</>
-);
+}): JSX.Element => {
+	const { t } = useTranslation();
+	return (
+		<>
+			<HtmlHead>{head}</HtmlHead>
+			<body>
+				<a href="#main" className={classes.skipLink}>
+					{t("skipToContent")}
+				</a>
+				<VirtualNavMenu />
+				<main id="main" className={className}>
+					{children}
+				</main>
+				<HtmlFooter />
+			</body>
+		</>
+	);
+};
 
 /**
  * HtmlHead
@@ -129,6 +136,7 @@ const loginForm = {
  */
 const HtmlFooter = ({ className }: { className?: string }): JSX.Element => {
 	const { renderContext } = useServerContext();
+	const { t } = useTranslation();
 	return (
 		<Section component="footer" className={className}>
 			<Row>


### PR DESCRIPTION
Fixes https://github.com/Jahia/javascript-modules/issues/317.

~Requires https://github.com/Jahia/javascript-modules/pull/639~

### Description
Use `useTranslation()` hook in server components: Replaced direct `import { t } from "i18next"` with usage of `useTranslation()` hook in all React server components. This ensures translations are context-aware and avoid hydration mismatches between server and client.


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
