### PR TITLE
fix: Correct translations for unknown errors

### DIFF
--- a/.chachalog/OahqZrzS.md
+++ b/.chachalog/OahqZrzS.md
@@ -1,0 +1,9 @@
+---
+# Allowed version bumps: patch, minor, major
+luxe-jahia-demo: patch
+---
+
+Correct translations for "unknown errors" (#405)
+
+The translations for the `form.login.unknownError` were stored under `form.unknownError` for all locales, causing the error message not to be displayed.
+Also, fix a typo ("occured" -> "occurred") in the English translation.

--- a/packages/template-set/settings/locales/de.json
+++ b/packages/template-set/settings/locales/de.json
@@ -78,7 +78,8 @@
 					"description": "Ich verwalte die Jahia-Plattform und stelle sicher, dass das System ordnungsgemäß konfiguriert und optimiert ist.",
 					"alt": "Benutzeravatar: {{username}}"
 				}
-			}
+			},
+			"unknownError": "ein Fehler ist aufgetreten"
 		},
 		"contact": {
 			"firstName": "Vorname",
@@ -94,7 +95,6 @@
 				"title": "kontaktieren sie uns"
 			}
 		},
-		"unknownError": "ein Fehler ist aufgetreten",
 		"estate": {
 			"placeholder": {
 				"bedrooms": "# Schlafzimmer",

--- a/packages/template-set/settings/locales/en.json
+++ b/packages/template-set/settings/locales/en.json
@@ -78,7 +78,8 @@
 					"description": "I administer the Jahia platform, ensuring that the system is properly configured and optimized.",
 					"alt": "User avatar: {{username}}"
 				}
-			}
+			},
+			"unknownError": "an error occurred"
 		},
 		"contact": {
 			"firstName": "firstname",
@@ -94,7 +95,6 @@
 				"title": "contact us"
 			}
 		},
-		"unknownError": "an error occured",
 		"estate": {
 			"placeholder": {
 				"bedrooms": "# bedrooms",

--- a/packages/template-set/settings/locales/es.json
+++ b/packages/template-set/settings/locales/es.json
@@ -78,7 +78,8 @@
 					"description": "Administro la plataforma Jahia, asegurando que el sistema esté correctamente configurado y optimizado.",
 					"alt": "Avatar del usuario: {{username}}"
 				}
-			}
+			},
+			"unknownError": "ocurrió un error"
 		},
 		"contact": {
 			"firstName": "nombre",
@@ -94,7 +95,6 @@
 				"title": "contáctanos"
 			}
 		},
-		"unknownError": "ocurrió un error",
 		"estate": {
 			"placeholder": {
 				"bedrooms": "# habitaciones",

--- a/packages/template-set/settings/locales/fr.json
+++ b/packages/template-set/settings/locales/fr.json
@@ -78,7 +78,8 @@
 					"description": "J'administre la plateforme Jahia, et veille à ce que le système soit correctement configuré et optimisé.",
 					"alt": "Avatar de l'utilisateur : {{username}}"
 				}
-			}
+			},
+			"unknownError": "une erreur s'est produite"
 		},
 		"contact": {
 			"firstName": "prénom",
@@ -94,7 +95,6 @@
 				"title": "nous contacter"
 			}
 		},
-		"unknownError": "une erreur s'est produite",
 		"estate": {
 			"placeholder": {
 				"bedrooms": "# chambres",


### PR DESCRIPTION
### Description
Fix translations for the unknown error messages.

The translations for `form.login.unknownError` were incorrectly stored under `form.unknownError` for all locales, causing the error message not to display.
Also fixes a typo ("occured" -> "occurred") in the English translation.

Found this issue while working on https://github.com/Jahia/user-password-authentication/issues/163.

<img width="1489" height="794" alt="Screenshot 2026-02-27 at 16 18 30" src="https://github.com/user-attachments/assets/71f4a1a0-6878-4afa-bfd6-abda2eb2ff6d" />


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
