### PR TITLE
feat: redirect persona card logins to the edition interface

### DIFF
--- a/.chachalog/xKp445pl.md
+++ b/.chachalog/xKp445pl.md
@@ -1,0 +1,5 @@
+---
+luxe-jahia-demo: minor
+---
+
+Clicking a persona card on the login dialog now opens the edition interface directly. (#445)

--- a/packages/template-set/src/components/Form/Login/Login.client.tsx
+++ b/packages/template-set/src/components/Form/Login/Login.client.tsx
@@ -53,6 +53,12 @@ export default function LoginClient({
 		setIsOpen(false);
 	};
 
+	// Persona cards are a guided demo entry point: land users directly in the
+	// edition interface (Page Builder) instead of staying on the live site.
+	const handlePersonaLoggedIn = () => {
+		window.location.assign(urls.editUrl);
+	};
+
 	if (mode === "edit") {
 		return (
 			<div className={clsx(alert.dark, classes.fs6)} role="alert">
@@ -104,6 +110,7 @@ export default function LoginClient({
 					isShowRememberMe={isShowRememberMe}
 					setUser={setUser}
 					handleLoggedIn={handleLoggedIn}
+					handlePersonaLoggedIn={handlePersonaLoggedIn}
 					siteKey={siteKey}
 					persona={persona}
 				/>

--- a/packages/template-set/src/components/Form/Login/LoginForm.client.tsx
+++ b/packages/template-set/src/components/Form/Login/LoginForm.client.tsx
@@ -12,6 +12,7 @@ interface LoginFormClientProps {
 	loginUrl: string;
 	setUser: Dispatch<SetStateAction<string | undefined>>;
 	handleLoggedIn: () => void;
+	handlePersonaLoggedIn: () => void;
 	isShowRememberMe: boolean;
 	siteKey?: string;
 	persona: LoginPersonaProps[];
@@ -21,6 +22,7 @@ const LoginFormClient = ({
 	loginUrl,
 	setUser,
 	handleLoggedIn,
+	handlePersonaLoggedIn,
 	siteKey,
 	isShowRememberMe = true,
 	persona,
@@ -41,6 +43,11 @@ const LoginFormClient = ({
 		setUnknownError,
 	};
 
+	const personaLoginProps: LoginCommonProps = {
+		...loginCommonProps,
+		handleLoggedIn: handlePersonaLoggedIn,
+	};
+
 	const handleLogin = () =>
 		login({
 			username,
@@ -57,7 +64,7 @@ const LoginFormClient = ({
 					<p>{t("form.login.sections.persona.teaser")}</p>
 					<div>
 						{persona?.map((user) => (
-							<LoginCardClient key={user.username} {...user} {...{ loginCommonProps }} />
+							<LoginCardClient key={user.username} {...user} loginCommonProps={personaLoginProps} />
 						))}
 					</div>
 				</div>

--- a/tests/cypress/e2e/forms/61-login.cy.ts
+++ b/tests/cypress/e2e/forms/61-login.cy.ts
@@ -1,4 +1,4 @@
-import { publishAndWaitJobEnding } from '@jahia/cypress'
+import { createUser, deleteUser, grantRoles, publishAndWaitJobEnding } from '@jahia/cypress'
 import { GENERIC_SITE_KEY } from '../../support/constants'
 
 const sitePath = `/sites/${GENERIC_SITE_KEY}`
@@ -39,9 +39,19 @@ const assertAnonymousCard = () => {
 }
 
 describe('Forms - 61 Login form (footer)', () => {
-	before('Publish the site', () => {
+	before('Publish the site and create the pam persona user', () => {
 		cy.login()
+		// The persona cards auto-login with hardcoded demo users; the generic test
+		// site does not import them, so the spec provides its own pam
+		createUser('pam', 'password')
+		grantRoles(sitePath, ['editor'], 'pam', 'USER')
 		publishAndWaitJobEnding(sitePath, ['en'])
+		cy.logout()
+	})
+
+	after('Delete the pam persona user', () => {
+		cy.login()
+		deleteUser('pam')
 		cy.logout()
 	})
 
@@ -60,6 +70,15 @@ describe('Forms - 61 Login form (footer)', () => {
 
 		cy.get('dialog').should('not.be.visible')
 		assertLoggedInCard('root')
+	})
+
+	it('logs in and lands in the edition interface when clicking a persona card (#352)', () => {
+		openLoginDialog()
+		cy.get('dialog').contains('h4', 'Pam Pasteur').closest('[role="button"]').click()
+
+		// The persona login redirects to the edit-mode URL of the current page,
+		// which the server resolves to the jContent Page Builder
+		cy.url({ timeout: 30000 }).should('include', '/jahia/jcontent')
 	})
 
 	it('shows the translated error on wrong credentials', () => {

--- a/tests/cypress/e2e/forms/61-login.cy.ts
+++ b/tests/cypress/e2e/forms/61-login.cy.ts
@@ -1,4 +1,4 @@
-import { createUser, deleteUser, grantRoles, publishAndWaitJobEnding } from '@jahia/cypress'
+import { createUser, deleteUser, getUserPath, grantRoles, publishAndWaitJobEnding } from '@jahia/cypress'
 import { GENERIC_SITE_KEY } from '../../support/constants'
 
 const sitePath = `/sites/${GENERIC_SITE_KEY}`
@@ -39,17 +39,32 @@ const assertAnonymousCard = () => {
 }
 
 describe('Forms - 61 Login form (footer)', () => {
-	before('Publish the site and create the pam persona user', () => {
+	// The persona cards auto-login with hardcoded demo users; the generic CI site
+	// does not import them, so the spec provisions its own pam. On a shared
+	// instance pam is a real demo user: deleting her would wipe her ACLs, so the
+	// spec must only clean up a user it created itself.
+	let pamCreatedBySpec = false
+
+	before('Publish the site and provision the pam persona user if missing', () => {
 		cy.login()
-		// The persona cards auto-login with hardcoded demo users; the generic test
-		// site does not import them, so the spec provides its own pam
-		createUser('pam', 'password')
-		grantRoles(sitePath, ['editor'], 'pam', 'USER')
+		getUserPath('pam').then((response) => {
+			if (response?.data?.admin?.userAdmin?.user) {
+				return
+			}
+
+			createUser('pam', 'password')
+			grantRoles(sitePath, ['editor'], 'pam', 'USER')
+			pamCreatedBySpec = true
+		})
 		publishAndWaitJobEnding(sitePath, ['en'])
 		cy.logout()
 	})
 
-	after('Delete the pam persona user', () => {
+	after('Delete the pam persona user if the spec created it', () => {
+		if (!pamCreatedBySpec) {
+			return
+		}
+
 		cy.login()
 		deleteUser('pam')
 		cy.logout()


### PR DESCRIPTION
### Description
Clicking a persona card in the login dialog now logs the user in and lands them directly in the edition interface (jContent Page Builder) of the current page, instead of staying on the live site. This makes the demo more beginner-friendly: you log in, then immediately get access to the restricted back office.

The classic username/password form keeps its current behavior (stay on the page, show the workspace links).

Implementation: the persona cards receive a dedicated `handleLoggedIn` callback that navigates to the `editUrl` already provided by the server component (built with `URLGenerator.getEdit()`, so vanity URLs, context path and rewriting are handled). The server resolves that URL to the jContent Page Builder, which then enforces each persona's own permissions.

Covered by a new case in the `61-login` Cypress spec (the generic test site does not import the demo users, so the spec now provisions its own `pam`).

Closes #352

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)