### PR TITLE
docs: link the filed platform issues from the srcset bug report draft

### DIFF
--- a/.harness/core-srcset-bug-report.md
+++ b/.harness/core-srcset-bug-report.md
@@ -1,6 +1,8 @@
 # Bug report — srcset URL rewriting corrupts URLs containing commas
 
-> Ready to paste into the core tracker. Found on 2026-07-08 while integrating the Cloudinary picker in a JavaScript module (luxe-jahia-demo, PR #436).
+> **Filed on 2026-08-06 as https://github.com/Jahia/jahia/issues/23** (label `need-triage`). Found on 2026-07-08 while integrating the Cloudinary picker in a JavaScript module (luxe-jahia-demo, PR #436). This file is kept as the working draft; follow the discussion on the issue.
+>
+> The two other platform findings from the e2e work were filed at the same time: Page Builder Delete crash → https://github.com/Jahia/jahia/issues/24, provisioning `importSite` site key → https://github.com/Jahia/jahia/issues/25.
 
 ## Summary
 


### PR DESCRIPTION
### Description

The three platform findings that surfaced while building the end-to-end coverage (#439) have now been filed on the core tracker:

- [Jahia/jahia#23](https://github.com/Jahia/jahia/issues/23) — `srcset` URL rewriting corrupts candidate URLs containing commas (found in #436), including the `<link rel="preload" imageSrcSet>` gap as suggested hardening
- [Jahia/jahia#24](https://github.com/Jahia/jahia/issues/24) — Page Builder context-menu **Delete** crashes with `TypeError: … (reading 'sort')`
- [Jahia/jahia#25](https://github.com/Jahia/jahia/issues/25) — provisioning `importSite` silently ignores the documented `siteKey` option

This adds those links at the top of the working draft `.harness/core-srcset-bug-report.md`, so the draft points to the filed issues instead of reading as something still waiting to be reported. Documentation only — no code, no behaviour change.

No changelog entry: `.harness/` holds internal working notes, so there is nothing user-facing to announce.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
